### PR TITLE
Document protected main workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,9 @@ Project-specific design and engineering rules live in:
   issue-less.
 - Keep each PR scoped to one planned task such as `M2-T08`, or one tightly related bundle small
   enough to review in one pass.
-- Treat CodeRabbit as advisory but mandatory to triage. Apply correctness, safety, recovery, test,
+- Treat CodeRabbit as part of the required review path when it is enabled on the repository.
+  Address every substantive CodeRabbit comment explicitly before merge by either applying the
+  change or documenting why it is not being applied. Apply correctness, safety, recovery, test,
   and docs-alignment feedback by default; document why you reject suggestions that would weaken
   determinism, boundedness, or trusted-core discipline.
 - After review-driven edits, rerun the relevant validation commands before considering the work

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,17 +72,21 @@ Add narrower commands too when they strengthen confidence for the specific chang
 
 - human review focuses first on correctness, regressions, missing tests, recovery behavior, and
   docs drift
-- CodeRabbit is advisory, but every substantial suggestion must be triaged explicitly
+- CodeRabbit is part of the review path when enabled on the repository
+- every CodeRabbit suggestion or comment that affects the PR must be addressed explicitly before
+  merge
 - apply CodeRabbit suggestions by default when they improve correctness, safety, testing,
   observability, or documentation
 - reject CodeRabbit suggestions when they add churn without value or weaken determinism,
   boundedness, dependency discipline, or trusted-core isolation
 
-Keep a short triage note in the PR description or comments:
+Addressing CodeRabbit means one of:
 
 - `applied`
 - `not applied`
 - short reason when not applied
+
+Do not leave substantive CodeRabbit comments unresolved or silently ignored.
 
 ## Merge Policy
 
@@ -104,8 +108,8 @@ The GitHub repository is configured so that `main`:
 - requires linear history
 - disallows force pushes and branch deletion
 
-CodeRabbit still needs to be verified on the first real PR and should stay part of the review path
-once confirmed.
+When enabled on the repository, CodeRabbit is part of the normal review path and its feedback must
+be addressed before merge.
 
 ## Labels And Milestones
 


### PR DESCRIPTION
## Summary
Document the branch protection settings that are now active on GitHub and make the CodeRabbit policy explicit.

## Linked Issue
Refs #4

## Changes
- record the protected-branch rules in CONTRIBUTING
- require CodeRabbit comments to be addressed explicitly before merge
- keep the written workflow aligned with the live repository settings

## Validation
- [x] scripts/check_repo.sh

## Docs
- [x] docs updated

## CodeRabbit Triage
- [x] applied: replaced the temporary rollout note with a durable policy and clarified that substantive CodeRabbit feedback must be explicitly addressed before merge


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * CodeRabbit feedback is now integrated into the required review path when enabled, with all substantive comments requiring resolution before merge.
  * Triage guidelines updated with explicit codes and categories for tracking applied and not-applied feedback.
  * Added Repository Guardrails section documenting main branch protections, including PR requirements, strict checks, resolved reviews, and linear history enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->