### PR TITLE
Implement safe checkpoint coordination

### DIFF
--- a/crates/allocdb-core/src/wal_file.rs
+++ b/crates/allocdb-core/src/wal_file.rs
@@ -1,4 +1,4 @@
-use std::fs::{File, OpenOptions};
+use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
@@ -44,11 +44,7 @@ impl WalFile {
     /// Returns [`WalFileError`] if the file cannot be opened or created.
     pub fn open(path: impl AsRef<Path>, max_payload_bytes: usize) -> Result<Self, WalFileError> {
         let path = path.as_ref().to_path_buf();
-        let file = OpenOptions::new()
-            .create(true)
-            .read(true)
-            .append(true)
-            .open(&path)?;
+        let file = open_append_file(&path)?;
 
         Ok(Self {
             path,
@@ -69,12 +65,7 @@ impl WalFile {
     /// Returns [`WalFileError::PayloadTooLarge`] if the frame payload exceeds the configured bound,
     /// or [`WalFileError::Io`] if the append fails.
     pub fn append_frame(&mut self, frame: &Frame) -> Result<(), WalFileError> {
-        if frame.payload.len() > self.max_payload_bytes {
-            return Err(WalFileError::PayloadTooLarge {
-                payload_len: frame.payload.len(),
-                max_payload_bytes: self.max_payload_bytes,
-            });
-        }
+        self.validate_payload_len(frame)?;
 
         let encoded = frame.encode();
         self.file.write_all(&encoded)?;
@@ -131,6 +122,57 @@ impl WalFile {
 
         Ok(recovered)
     }
+
+    /// Replaces the on-disk WAL contents with one new ordered frame set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WalFileError::PayloadTooLarge`] if any frame exceeds the configured payload
+    /// bound, or [`WalFileError::Io`] if the temp-file rewrite, rename, or reopen fails.
+    pub fn replace_with_frames(&mut self, frames: &[Frame]) -> Result<(), WalFileError> {
+        for frame in frames {
+            self.validate_payload_len(frame)?;
+        }
+
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let temp_path = self.temp_path();
+        {
+            let mut temp_file = File::create(&temp_path)?;
+            for frame in frames {
+                temp_file.write_all(&frame.encode())?;
+            }
+            temp_file.sync_data()?;
+        }
+
+        fs::rename(&temp_path, &self.path)?;
+        sync_parent_dir(&self.path)?;
+        self.file = open_append_file(&self.path)?;
+        Ok(())
+    }
+
+    fn validate_payload_len(&self, frame: &Frame) -> Result<(), WalFileError> {
+        if frame.payload.len() > self.max_payload_bytes {
+            return Err(WalFileError::PayloadTooLarge {
+                payload_len: frame.payload.len(),
+                max_payload_bytes: self.max_payload_bytes,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn temp_path(&self) -> PathBuf {
+        let mut temp_path = self.path.clone();
+        let extension = temp_path
+            .extension()
+            .and_then(|value| value.to_str())
+            .map_or_else(|| "tmp".to_owned(), |value| format!("{value}.tmp"));
+        temp_path.set_extension(extension);
+        temp_path
+    }
 }
 
 fn recover_path(path: &Path) -> Result<RecoveredWal, WalFileError> {
@@ -142,6 +184,27 @@ fn recover_path(path: &Path) -> Result<RecoveredWal, WalFileError> {
         scan_result,
         file_len: u64::try_from(bytes.len()).expect("file length must fit into u64"),
     })
+}
+
+fn open_append_file(path: &Path) -> Result<File, std::io::Error> {
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .append(true)
+        .open(path)
+}
+
+#[cfg(unix)]
+fn sync_parent_dir(path: &Path) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        OpenOptions::new().read(true).open(parent)?.sync_all()?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_path: &Path) -> Result<(), std::io::Error> {
+    Ok(())
 }
 
 #[cfg(test)]
@@ -294,6 +357,24 @@ mod tests {
             } if offset == first_len
         ));
         assert_eq!(fs::metadata(&path).unwrap().len(), original_len);
+
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn wal_file_replace_with_frames_rewrites_contents() {
+        let path = test_path("rewrite");
+        let mut wal = WalFile::open(&path, 64).unwrap();
+        wal.append_frame(&frame(1, 1, b"one")).unwrap();
+        wal.append_frame(&frame(2, 2, b"two")).unwrap();
+        wal.sync().unwrap();
+
+        let rewritten = vec![frame(2, 2, b"two"), frame(3, 3, b"three")];
+        wal.replace_with_frames(&rewritten).unwrap();
+
+        let recovered = wal.recover().unwrap();
+        assert_eq!(recovered.scan_result.frames, rewritten);
+        assert_eq!(recovered.scan_result.stop_reason, ScanStopReason::CleanEof);
 
         fs::remove_file(path).unwrap();
     }

--- a/crates/allocdb-node/src/engine.rs
+++ b/crates/allocdb-node/src/engine.rs
@@ -15,11 +15,17 @@ use allocdb_core::wal_file::{WalFile, WalFileError};
 
 use crate::bounded_queue::{BoundedQueue, BoundedQueueError};
 
+#[path = "engine_checkpoint.rs"]
+mod checkpoint;
+#[cfg(test)]
+#[path = "engine_checkpoint_tests.rs"]
+mod checkpoint_tests;
 #[path = "engine_observe.rs"]
 mod observe;
 #[cfg(test)]
 #[path = "engine_tests.rs"]
 mod tests;
+pub use checkpoint::{CheckpointError, CheckpointResult};
 pub use observe::{EngineMetrics, ReadError};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -173,6 +179,7 @@ pub struct SingleNodeEngine {
     config: EngineConfig,
     next_lsn: u64,
     accepting_writes: bool,
+    active_snapshot_lsn: Option<Lsn>,
 }
 
 impl SingleNodeEngine {
@@ -188,7 +195,7 @@ impl SingleNodeEngine {
         wal_path: impl AsRef<Path>,
     ) -> Result<Self, EngineOpenError> {
         let db = AllocDb::new(core_config)?;
-        Self::from_parts(db, engine_config, wal_path)
+        Self::from_parts(db, engine_config, wal_path, None)
     }
 
     /// Recovers one engine from snapshot plus WAL, then reopens the live WAL path for new writes.
@@ -211,7 +218,13 @@ impl SingleNodeEngine {
         let wal = WalFile::open(wal_path.as_ref(), engine_config.max_command_bytes)
             .map_err(EngineOpenError::from)?;
         let recovered = recover_allocdb(core_config, &snapshot_file, &wal)?;
-        Self::from_parts(recovered.db, engine_config, wal_path).map_err(RecoverEngineError::from)
+        Self::from_parts(
+            recovered.db,
+            engine_config,
+            wal_path,
+            recovered.loaded_snapshot_lsn,
+        )
+        .map_err(RecoverEngineError::from)
     }
 
     /// Builds one engine around an existing allocator state, for example after recovery.
@@ -228,6 +241,7 @@ impl SingleNodeEngine {
         db: AllocDb,
         engine_config: EngineConfig,
         wal_path: impl AsRef<Path>,
+        active_snapshot_lsn: Option<Lsn>,
     ) -> Result<Self, EngineOpenError> {
         engine_config.validate()?;
         let wal = WalFile::open(wal_path, engine_config.max_command_bytes)?;
@@ -243,6 +257,7 @@ impl SingleNodeEngine {
             config: engine_config,
             next_lsn,
             accepting_writes: true,
+            active_snapshot_lsn,
         })
     }
 

--- a/crates/allocdb-node/src/engine_checkpoint.rs
+++ b/crates/allocdb-node/src/engine_checkpoint.rs
@@ -1,0 +1,147 @@
+use std::path::Path;
+
+use allocdb_core::ids::{Lsn, Slot};
+use allocdb_core::snapshot_file::{SnapshotFile, SnapshotFileError};
+use allocdb_core::wal::{Frame, RecordType, ScanStopReason};
+use allocdb_core::wal_file::{RecoveredWal, WalFileError};
+
+use crate::engine::SingleNodeEngine;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CheckpointResult {
+    pub snapshot_lsn: Option<Lsn>,
+    pub previous_snapshot_lsn: Option<Lsn>,
+    pub retained_frame_count: usize,
+}
+
+#[derive(Debug)]
+pub enum CheckpointError {
+    EngineHalted,
+    QueueNotEmpty {
+        queue_depth: u32,
+    },
+    SnapshotFile(SnapshotFileError),
+    WalFile(WalFileError),
+    WalNotClean(ScanStopReason),
+    WalStateMismatch {
+        wal_last_lsn: Option<Lsn>,
+        snapshot_lsn: Option<Lsn>,
+    },
+}
+
+impl From<SnapshotFileError> for CheckpointError {
+    fn from(error: SnapshotFileError) -> Self {
+        Self::SnapshotFile(error)
+    }
+}
+
+impl From<WalFileError> for CheckpointError {
+    fn from(error: WalFileError) -> Self {
+        Self::WalFile(error)
+    }
+}
+
+impl SingleNodeEngine {
+    /// Persists one new snapshot and rewrites the WAL with one-checkpoint overlap.
+    ///
+    /// The new snapshot becomes the active anchor, but retained WAL history still starts after the
+    /// previously successful snapshot anchor so recovery remains safe across checkpoint replacement.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CheckpointError`] if the engine is halted, queued writes still exist, the WAL is
+    /// not clean, or snapshot/WAL persistence fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if validated queue bounds no longer fit into `u32`.
+    pub fn checkpoint(
+        &mut self,
+        snapshot_path: impl AsRef<Path>,
+    ) -> Result<CheckpointResult, CheckpointError> {
+        if !self.accepting_writes {
+            return Err(CheckpointError::EngineHalted);
+        }
+
+        if self.queue.len() != 0 {
+            return Err(CheckpointError::QueueNotEmpty {
+                queue_depth: u32::try_from(self.queue.len()).expect("queue depth must fit u32"),
+            });
+        }
+
+        let snapshot = self.db.snapshot();
+        let recovered_wal = self.require_clean_wal().inspect_err(|_| {
+            self.accepting_writes = false;
+        })?;
+        let wal_last_lsn = recovered_wal
+            .scan_result
+            .frames
+            .last()
+            .map(|frame| frame.lsn);
+        if wal_last_lsn != snapshot.last_applied_lsn {
+            self.accepting_writes = false;
+            return Err(CheckpointError::WalStateMismatch {
+                wal_last_lsn,
+                snapshot_lsn: snapshot.last_applied_lsn,
+            });
+        }
+
+        let previous_snapshot_lsn = self.active_snapshot_lsn;
+        let snapshot_file = SnapshotFile::new(snapshot_path);
+        snapshot_file.write_snapshot(&snapshot)?;
+
+        let retained_frames = retained_frames(
+            &recovered_wal,
+            previous_snapshot_lsn,
+            snapshot.last_applied_lsn,
+            snapshot.last_request_slot,
+        );
+        if let Err(error) = self.wal.replace_with_frames(&retained_frames) {
+            self.accepting_writes = false;
+            self.active_snapshot_lsn = snapshot.last_applied_lsn;
+            return Err(CheckpointError::WalFile(error));
+        }
+        self.active_snapshot_lsn = snapshot.last_applied_lsn;
+
+        Ok(CheckpointResult {
+            snapshot_lsn: snapshot.last_applied_lsn,
+            previous_snapshot_lsn,
+            retained_frame_count: retained_frames.len(),
+        })
+    }
+
+    fn require_clean_wal(&self) -> Result<RecoveredWal, CheckpointError> {
+        let recovered = self.wal.recover()?;
+        match recovered.scan_result.stop_reason {
+            ScanStopReason::CleanEof => Ok(recovered),
+            stop_reason => Err(CheckpointError::WalNotClean(stop_reason)),
+        }
+    }
+}
+
+fn retained_frames(
+    recovered_wal: &RecoveredWal,
+    previous_snapshot_lsn: Option<Lsn>,
+    snapshot_lsn: Option<Lsn>,
+    snapshot_request_slot: Option<Slot>,
+) -> Vec<Frame> {
+    let retention_floor = previous_snapshot_lsn.map_or(0, Lsn::get);
+    let mut retained: Vec<_> = recovered_wal
+        .scan_result
+        .frames
+        .iter()
+        .filter(|frame| frame.lsn.get() > retention_floor)
+        .cloned()
+        .collect();
+
+    if let Some(snapshot_lsn) = snapshot_lsn {
+        retained.push(Frame {
+            lsn: snapshot_lsn,
+            request_slot: snapshot_request_slot.unwrap_or(Slot(0)),
+            record_type: RecordType::SnapshotMarker,
+            payload: Vec::new(),
+        });
+    }
+
+    retained
+}

--- a/crates/allocdb-node/src/engine_checkpoint_tests.rs
+++ b/crates/allocdb-node/src/engine_checkpoint_tests.rs
@@ -1,0 +1,182 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use allocdb_core::ResourceState;
+use allocdb_core::command::{ClientRequest, Command};
+use allocdb_core::config::Config;
+use allocdb_core::ids::{ClientId, HolderId, Lsn, OperationId, ReservationId, ResourceId, Slot};
+use allocdb_core::snapshot_file::SnapshotFile;
+use allocdb_core::wal::{RecordType, ScanStopReason};
+use allocdb_core::wal_file::WalFile;
+
+use crate::engine::{CheckpointError, EngineConfig, SingleNodeEngine};
+
+fn test_path(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("allocdb-checkpoint-{name}-{nanos}.wal"))
+}
+
+fn core_config() -> Config {
+    Config {
+        shard_id: 0,
+        max_resources: 8,
+        max_reservations: 8,
+        max_operations: 16,
+        max_ttl_slots: 16,
+        max_client_retry_window_slots: 8,
+        reservation_history_window_slots: 4,
+        max_expiration_bucket_len: 8,
+    }
+}
+
+fn engine_config() -> EngineConfig {
+    EngineConfig {
+        max_submission_queue: 2,
+        max_command_bytes: 512,
+    }
+}
+
+fn create(resource_id: u128, operation_id: u128) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::CreateResource {
+            resource_id: ResourceId(resource_id),
+        },
+    }
+}
+
+fn reserve(resource_id: u128, operation_id: u128, holder_id: u128) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::Reserve {
+            resource_id: ResourceId(resource_id),
+            holder_id: HolderId(holder_id),
+            ttl_slots: 3,
+        },
+    }
+}
+
+fn confirm(reservation_id: u128, operation_id: u128, holder_id: u128) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::Confirm {
+            reservation_id: ReservationId(reservation_id),
+            holder_id: HolderId(holder_id),
+        },
+    }
+}
+
+#[test]
+fn checkpoint_rejects_queued_submissions() {
+    let wal_path = test_path("queue-not-empty");
+    let snapshot_path = wal_path.with_extension("snapshot");
+    let mut engine = SingleNodeEngine::open(core_config(), engine_config(), &wal_path).unwrap();
+
+    engine.enqueue_client(Slot(1), create(11, 1)).unwrap();
+    let error = engine.checkpoint(&snapshot_path).unwrap_err();
+
+    assert!(matches!(
+        error,
+        CheckpointError::QueueNotEmpty { queue_depth: 1 }
+    ));
+
+    let _ = fs::remove_file(wal_path);
+    let _ = fs::remove_file(snapshot_path);
+}
+
+#[test]
+fn checkpoint_rewrites_wal_with_one_checkpoint_overlap() {
+    let wal_path = test_path("overlap");
+    let snapshot_path = wal_path.with_extension("snapshot");
+    let mut engine = SingleNodeEngine::open(core_config(), engine_config(), &wal_path).unwrap();
+
+    engine.submit(Slot(1), create(11, 1)).unwrap();
+    let first = engine.checkpoint(&snapshot_path).unwrap();
+    assert_eq!(first.snapshot_lsn, Some(Lsn(1)));
+    assert_eq!(first.previous_snapshot_lsn, None);
+
+    engine.submit(Slot(2), reserve(11, 2, 5)).unwrap();
+    engine.submit(Slot(3), confirm(2, 3, 5)).unwrap();
+    let second = engine.checkpoint(&snapshot_path).unwrap();
+
+    assert_eq!(second.snapshot_lsn, Some(Lsn(3)));
+    assert_eq!(second.previous_snapshot_lsn, Some(Lsn(1)));
+
+    let wal = WalFile::open(&wal_path, engine_config().max_command_bytes).unwrap();
+    let recovered_wal = wal.recover().unwrap();
+    let retained: Vec<_> = recovered_wal
+        .scan_result
+        .frames
+        .iter()
+        .map(|frame| (frame.lsn, frame.record_type))
+        .collect();
+
+    assert_eq!(
+        recovered_wal.scan_result.stop_reason,
+        ScanStopReason::CleanEof
+    );
+    assert_eq!(
+        retained,
+        vec![
+            (Lsn(2), RecordType::ClientCommand),
+            (Lsn(3), RecordType::ClientCommand),
+            (Lsn(3), RecordType::SnapshotMarker),
+        ]
+    );
+
+    let recovered_engine =
+        SingleNodeEngine::recover(core_config(), engine_config(), &snapshot_path, &wal_path)
+            .unwrap();
+    assert_eq!(
+        recovered_engine
+            .db()
+            .resource(ResourceId(11))
+            .unwrap()
+            .current_state,
+        ResourceState::Confirmed
+    );
+
+    fs::remove_file(wal_path).unwrap();
+    fs::remove_file(snapshot_path).unwrap();
+}
+
+#[test]
+fn recovery_survives_new_snapshot_before_wal_rewrite() {
+    let wal_path = test_path("snapshot-before-rewrite");
+    let snapshot_path = wal_path.with_extension("snapshot");
+    let mut engine = SingleNodeEngine::open(core_config(), engine_config(), &wal_path).unwrap();
+
+    engine.submit(Slot(1), create(11, 1)).unwrap();
+    engine.checkpoint(&snapshot_path).unwrap();
+    engine.submit(Slot(2), reserve(11, 2, 5)).unwrap();
+    engine.submit(Slot(3), confirm(2, 3, 5)).unwrap();
+
+    let snapshot_file = SnapshotFile::new(&snapshot_path);
+    snapshot_file
+        .write_snapshot(&engine.db().snapshot())
+        .unwrap();
+    drop(engine);
+
+    let recovered =
+        SingleNodeEngine::recover(core_config(), engine_config(), &snapshot_path, &wal_path)
+            .unwrap();
+
+    assert_eq!(
+        recovered
+            .db()
+            .resource(ResourceId(11))
+            .unwrap()
+            .current_state,
+        ResourceState::Confirmed
+    );
+
+    fs::remove_file(wal_path).unwrap();
+    fs::remove_file(snapshot_path).unwrap();
+}

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -51,9 +51,15 @@ Current observability surface:
 - expose operation-table utilization so dedupe-window pressure is visible before hard rejection
 - expose queue depth and write-acceptance state through the single-node engine wrapper
 
+Current durability shape before alpha:
+
+- the WAL is one append-only file on the live path
+- checkpoints rewrite retained WAL history through a temp-file and rename path
+- retained WAL keeps one-checkpoint overlap and appends a `snapshot_marker` at the active snapshot
+  anchor
+
 Next hardening steps before alpha are:
 
-- formalize snapshot-safe WAL truncation with an overlapping checkpoint rule
 - surface recovery status alongside the current lag and backlog signals
 - preserve definite-vs-indefinite submission categories in the external wire protocol
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -10,7 +10,7 @@
   - `M0` semantics freeze: complete enough for core work
   - `M1` pure state machine: implemented
   - `M1H` constant-time core hardening: complete
-  - `M2` durability primitives: partially implemented
+  - `M2` durability and recovery: implemented
   - `M3` submission pipeline: in progress
   - `M4+` simulation, alpha hardening, replication design: not started
 - Latest completed implementation chunks:
@@ -22,8 +22,8 @@
   - `3d6ff0f` `Fail closed on WAL corruption`
   - `39f103b` `Defer conditional confirm and add health metrics`
   - `82cb8d8` `Add single-node submission engine crate`
-  - current validated chunk: explicit submission error categories and dedupe-window utilization
-    signal
+  - current validated chunk: safe checkpoint coordination with one-checkpoint WAL overlap and
+    snapshot-marker retention
 
 ## What Exists
 
@@ -51,20 +51,17 @@
   - snapshot encode, decode, capture, restore
   - file-backed snapshot write and load
   - explicit WAL command payload encoding and live-path replay recovery
+  - checkpoint path that writes the new snapshot first, then rewrites retained WAL history
+  - one-checkpoint WAL overlap and `snapshot_marker` retention for safe checkpoint replacement
 - Validation:
-  - `cargo fmt --all`
-  - `cargo clippy --all-targets --all-features -- -D warnings`
-  - `cargo test`
-  - `scripts/check_repo.sh`
+  - `scripts/preflight.sh`
 
 ## Current Focus
 
-- `M2-T08`: tighten WAL/snapshot checkpoint coordination on top of the current recovery path
-- `M2-T08`: implement a safe truncation rule that preserves overlap through the previous
-  checkpoint anchor
 - `M3-T06`: finish the remaining submission semantics around indefinite outcomes after write/sync
   failure
 - `M5-T02`: expose recovery status alongside the current queue-pressure and core-health signals
+- prepare the wire/API side of the single-node alpha on top of the now-complete durability layer
 
 ## How To Check Progress
 

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -6,7 +6,10 @@ This document defines the v1 WAL, snapshot, and crash-recovery model.
 
 ## WAL
 
-Use segmented append-only WAL files.
+The current implementation uses one append-only WAL file.
+
+Segmented WAL retention remains a plausible future refinement, but v1 now achieves safe checkpoint
+coordination by rewriting the retained WAL prefix through a temp-file and rename path.
 
 Each frame includes:
 
@@ -39,9 +42,9 @@ Current implementation anchor:
 
 The current code covers frame encoding, decoding, checksum validation, and in-memory recovery
 scanning up to the last valid frame boundary, explicit command-payload encoding for client and
-internal commands, plus file-backed append, sync, recovery scan, and truncate-to-valid-prefix
-behavior for one WAL file. Recovery distinguishes a crash-torn tail from durable-log corruption:
-only torn tails are truncated automatically.
+internal commands, file-backed append, sync, recovery scan, truncate-to-valid-prefix behavior for
+one WAL file, and safe WAL rewrite during checkpoint retention. Recovery distinguishes a
+crash-torn tail from durable-log corruption: only torn tails are truncated automatically.
 
 ## Snapshots
 
@@ -80,7 +83,7 @@ Recovery implementation anchors:
 Recovery is:
 
 1. load the latest valid snapshot
-2. scan later WAL segments in LSN order
+2. scan later WAL frames in LSN order
 3. verify checksums
 4. replay frames into a fresh state machine
 5. rebuild transient scheduler state from persisted state
@@ -98,19 +101,21 @@ Current behavior:
 - recovery loads the latest snapshot first
 - replay skips WAL frames at or below the snapshot's `last_applied_lsn`
 - snapshot writing is atomic at the file level through temp-file, fsync, and rename discipline
+- the engine tracks the active snapshot anchor explicitly in memory
+- each successful checkpoint rewrites the WAL through a temp-file and rename path
+- rewritten WAL retains frames with `lsn > previous_snapshot_lsn`, preserving one-checkpoint
+  overlap
+- rewritten WAL appends a `snapshot_marker` frame at the active snapshot anchor so the retained WAL
+  makes the current checkpoint boundary explicit
 
-Current limitation:
+Crash-safety rule:
 
-- the system does not yet perform snapshot-driven WAL prefix truncation after a successful
-  checkpoint
-- because the current WAL implementation is one file, safe truncation requires either a prefix
-  rewrite or segmented WAL files; suffix truncation is not enough
-
-Required follow-up rule:
-
-- any future checkpoint truncation must leave overlapping history through the previously successful
-  snapshot anchor, so a crash during or after snapshot replacement never strands recovery without a
-  durable path back to the latest stable checkpoint
+- snapshot replacement happens before WAL rewrite, so a crash after the new snapshot becomes
+  durable but before WAL rewrite completes still recovers from the new snapshot plus the old WAL
+- WAL rewrite uses temp-file, fsync, rename, and directory-sync discipline, so a crash during
+  rewrite leaves either the old retained WAL or the fully rewritten retained WAL
+- any future segmented implementation must preserve the same one-checkpoint overlap rule; suffix
+  truncation alone is not enough
 
 ## Design Notes
 

--- a/docs/work-breakdown.md
+++ b/docs/work-breakdown.md
@@ -558,7 +558,7 @@ Test evidence:
 
 Goal:
 
-- append validated frames to segmented WAL files
+- append validated frames to the live WAL file
 
 Blocked by:
 
@@ -577,7 +577,7 @@ Test evidence:
 
 Goal:
 
-- scan WAL segments and stop at the last valid boundary
+- scan WAL history and stop at the last valid boundary
 
 Blocked by:
 


### PR DESCRIPTION
## Summary
Implement `M2-T08` by adding safe checkpoint coordination, one-checkpoint WAL overlap retention, and crash-safety tests for snapshot-plus-WAL recovery.

## Linked Issue
Refs #1

## Changes
- add `SingleNodeEngine::checkpoint()` with explicit active snapshot anchor tracking
- rewrite retained WAL history through a temp-file and rename path instead of pretending suffix truncation is enough
- retain one-checkpoint overlap and append `snapshot_marker` frames at the active snapshot anchor
- add checkpoint-specific tests for overlap retention, queue safety, and recovery after snapshot replacement before WAL rewrite
- update the storage and status docs to match the actual implementation shape

## Validation
- [x] `scripts/preflight.sh`

## Docs
- [x] docs updated

## CodeRabbit Triage
- [ ] pending review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced engine checkpointing to safely persist snapshots and manage write-ahead log retention.
  * Added atomic WAL replacement mechanism for crash-safe checkpoint coordination.

* **Documentation**
  * Updated durability, recovery, and storage architecture documentation to reflect checkpoint implementation.
  * Clarified single-file WAL model and crash-safety guarantees.

* **Tests**
  * Added comprehensive checkpoint and recovery validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->