### PR TITLE
fix: prevent FixedMap deletions from stranding live operations

### DIFF
--- a/crates/allocdb-core/src/fixed_map.rs
+++ b/crates/allocdb-core/src/fixed_map.rs
@@ -213,13 +213,13 @@ impl<K: FixedKey, V> FixedMap<K, V> {
                 }
                 Bucket::Occupied { key, slot } => {
                     let ideal = self.bucket_index(key);
-                    if self.probe_distance(ideal, current) == 0 {
-                        self.buckets[gap] = Bucket::Empty;
-                        break;
+                    // Keep scanning until the cluster ends. A key sitting in its ideal bucket does
+                    // not terminate the repair because later wrapped keys can still probe through
+                    // the current gap.
+                    if self.probe_distance(ideal, gap) < self.probe_distance(ideal, current) {
+                        self.buckets[gap] = Bucket::Occupied { key, slot };
+                        gap = current;
                     }
-
-                    self.buckets[gap] = Bucket::Occupied { key, slot };
-                    gap = current;
                     current = self.next_bucket(current);
                 }
             }
@@ -277,6 +277,18 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct PositionedKey {
+        id: u64,
+        hash: u64,
+    }
+
+    impl FixedKey for PositionedKey {
+        fn hash64(self) -> u64 {
+            self.hash
+        }
+    }
+
     #[test]
     fn insert_get_and_remove_round_trip() {
         let mut map = FixedMap::with_capacity(4);
@@ -315,5 +327,24 @@ mod tests {
         assert_eq!(map.remove(CollidingKey(1)), Some(10));
         assert_eq!(map.get(CollidingKey(2)), Some(&20));
         assert_eq!(map.get(CollidingKey(3)), Some(&30));
+    }
+
+    #[test]
+    fn deletion_preserves_wrapped_probe_chain_past_home_bucket() {
+        let mut map = FixedMap::with_capacity(4);
+        let removed = PositionedKey { id: 1, hash: 6 };
+        let home = PositionedKey { id: 2, hash: 7 };
+        let wrapped = PositionedKey { id: 3, hash: 6 };
+        let displaced = PositionedKey { id: 4, hash: 0 };
+
+        map.insert(removed, 10).unwrap();
+        map.insert(home, 20).unwrap();
+        map.insert(wrapped, 30).unwrap();
+        map.insert(displaced, 40).unwrap();
+
+        assert_eq!(map.remove(removed), Some(10));
+        assert_eq!(map.get(home), Some(&20));
+        assert_eq!(map.get(wrapped), Some(&30));
+        assert_eq!(map.get(displaced), Some(&40));
     }
 }

--- a/crates/allocdb-core/src/state_machine.rs
+++ b/crates/allocdb-core/src/state_machine.rs
@@ -11,6 +11,9 @@ use crate::retire_queue::{RetireEntry, RetireQueue, RetireQueueError};
 mod apply;
 #[path = "state_machine_execution.rs"]
 mod execution;
+#[cfg(test)]
+#[path = "state_machine_issue_32_tests.rs"]
+mod issue_32_tests;
 #[path = "state_machine_metrics.rs"]
 mod metrics;
 #[cfg(test)]

--- a/crates/allocdb-core/src/state_machine_issue_32_tests.rs
+++ b/crates/allocdb-core/src/state_machine_issue_32_tests.rs
@@ -1,0 +1,68 @@
+use crate::command::{ClientRequest, Command, CommandContext};
+use crate::config::Config;
+use crate::ids::{ClientId, Lsn, OperationId, ResourceId, Slot};
+use crate::result::ResultCode;
+use crate::state_machine::AllocDb;
+
+fn config() -> Config {
+    Config {
+        shard_id: 0,
+        max_resources: 8,
+        max_reservations: 8,
+        max_operations: 4,
+        max_ttl_slots: 2,
+        max_client_retry_window_slots: 0,
+        reservation_history_window_slots: 1,
+        max_expiration_bucket_len: 8,
+    }
+}
+
+fn context(lsn: u64, request_slot: u64) -> CommandContext {
+    CommandContext {
+        lsn: Lsn(lsn),
+        request_slot: Slot(request_slot),
+    }
+}
+
+fn create_with_operation(operation_id: u128, resource_id: u128) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::CreateResource {
+            resource_id: ResourceId(resource_id),
+        },
+    }
+}
+
+#[test]
+fn operation_reuse_conflict_survives_probe_chain_retirement_gap() {
+    let mut db = AllocDb::new(config()).unwrap();
+
+    let first = db.apply_client(context(1, 1), create_with_operation(22, 1));
+    let second = db.apply_client(context(2, 2), create_with_operation(4, 1));
+    let third = db.apply_client(context(3, 3), create_with_operation(26, 1));
+
+    assert_eq!(first.result_code, ResultCode::Ok);
+    assert_eq!(second.result_code, ResultCode::AlreadyExists);
+    assert_eq!(third.result_code, ResultCode::AlreadyExists);
+
+    let unrelated = db.apply_client(context(4, 4), create_with_operation(1, 2));
+    assert_eq!(unrelated.result_code, ResultCode::Ok);
+
+    assert!(db.operation(OperationId(22), Slot(4)).is_none());
+    assert_eq!(
+        db.operation(OperationId(4), Slot(4))
+            .map(|record| record.result_code),
+        Some(ResultCode::AlreadyExists)
+    );
+    assert_eq!(
+        db.operation(OperationId(26), Slot(4))
+            .map(|record| record.result_code),
+        Some(ResultCode::AlreadyExists)
+    );
+
+    let conflicting = db.apply_client(context(5, 4), create_with_operation(26, 3));
+
+    assert_eq!(conflicting.result_code, ResultCode::OperationConflict);
+    assert!(db.resource(ResourceId(3)).is_none());
+}


### PR DESCRIPTION
## Summary
- fix `FixedMap::close_deletion_gap()` so linear-probing deletions repair the full live cluster instead of stopping at the first home-bucket entry
- add a low-level regression for the wrapped probe-chain case that previously stranded lookups
- add the exact `AllocDb` reproduction from issue #32 to verify conflicting `operation_id` reuse still returns `OperationConflict`

## Reviewer Note
The subtle invariant is that a key sitting in its ideal bucket does not end deletion-gap repair; a later wrapped key can still depend on the gap being filled. The move condition is now expressed as whether the gap lies strictly inside the key's probe distance.

## Validation
- `cargo test -p allocdb-core`
- `./scripts/preflight.sh`

Closes #32
