### PR TITLE
M4-T03 Inject storage faults

### DIFF
--- a/crates/allocdb-node/src/engine.rs
+++ b/crates/allocdb-node/src/engine.rs
@@ -217,6 +217,7 @@ impl StartupRecovery {
 pub(crate) enum PersistFailurePhase {
     BeforeAppend,
     AfterAppend,
+    Sync,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -759,6 +760,16 @@ impl SingleNodeEngine {
             ));
         }
 
+        if injected_failure == Some(PersistFailurePhase::Sync) {
+            return Err(self.halt_on_wal_error(
+                operation_id,
+                pending.request_slot,
+                applied_lsn,
+                "sync",
+                std::io::Error::other("injected WAL sync failure"),
+            ));
+        }
+
         if let Err(error) = self.wal.sync() {
             return Err(self.halt_on_wal_error(
                 operation_id,
@@ -887,6 +898,15 @@ impl SingleNodeEngine {
                 applied_lsn,
                 "after_append_before_sync",
                 std::io::Error::other("injected WAL failure after append"),
+            ));
+        }
+
+        if injected_failure == Some(PersistFailurePhase::Sync) {
+            return Err(self.halt_on_internal_wal_error(
+                request_slot,
+                applied_lsn,
+                "sync",
+                std::io::Error::other("injected WAL sync failure"),
             ));
         }
 

--- a/crates/allocdb-node/src/simulation.rs
+++ b/crates/allocdb-node/src/simulation.rs
@@ -20,6 +20,14 @@ mod tests;
 static NEXT_SIMULATION_WORKSPACE_ID: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum StorageFault {
+    AppendFailure,
+    SyncFailure,
+    CorruptLastFrameChecksum,
+    TornLastFrameTail { truncate_bytes: u64 },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct SimulationObservation {
     pub slot: Slot,
     pub operation_id: OperationId,
@@ -186,8 +194,23 @@ impl SimulationHarness {
         Ok(metrics)
     }
 
-    pub(crate) fn inject_next_persist_failure(&mut self, phase: PersistFailurePhase) {
-        self.engine_mut().inject_next_persist_failure(phase);
+    pub(crate) fn inject_storage_fault(&mut self, fault: StorageFault) {
+        match fault {
+            StorageFault::AppendFailure => self
+                .engine_mut()
+                .inject_next_persist_failure(PersistFailurePhase::BeforeAppend),
+            StorageFault::SyncFailure => self
+                .engine_mut()
+                .inject_next_persist_failure(PersistFailurePhase::Sync),
+            StorageFault::CorruptLastFrameChecksum => {
+                drop(self.engine.take());
+                corrupt_last_wal_byte(&self.wal_path);
+            }
+            StorageFault::TornLastFrameTail { truncate_bytes } => {
+                drop(self.engine.take());
+                truncate_wal_tail(&self.wal_path, truncate_bytes);
+            }
+        }
     }
 
     pub(crate) fn arm_next_engine_crash(
@@ -245,4 +268,37 @@ fn simulation_workspace_path(name: &str, seed: u64) -> PathBuf {
     std::env::temp_dir().join(format!(
         "allocdb-sim-{name}-seed-{seed}-pid-{process_id}-run-{workspace_id}"
     ))
+}
+
+fn corrupt_last_wal_byte(path: &PathBuf) {
+    let mut bytes = fs::read(path).expect("recovery fault requires one WAL file");
+    assert!(
+        !bytes.is_empty(),
+        "checksum mismatch requires one non-empty WAL"
+    );
+    let last_index = bytes.len() - 1;
+    bytes[last_index] ^= 0xff;
+    fs::write(path, bytes).expect("checksum mismatch must rewrite WAL bytes");
+}
+
+fn truncate_wal_tail(path: &PathBuf, truncated_bytes: u64) {
+    assert!(
+        truncated_bytes > 0,
+        "torn tail requires one positive truncation"
+    );
+    let file_len = fs::metadata(path)
+        .expect("torn tail requires one WAL file")
+        .len();
+    assert!(
+        file_len > truncated_bytes,
+        "torn tail must leave at least one valid WAL byte behind"
+    );
+    let file = fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .expect("torn tail requires one writable WAL");
+    file.set_len(file_len - truncated_bytes)
+        .expect("torn tail truncation must succeed");
+    file.sync_data()
+        .expect("torn tail truncation must sync the shortened file");
 }

--- a/crates/allocdb-node/src/simulation_tests.rs
+++ b/crates/allocdb-node/src/simulation_tests.rs
@@ -1,13 +1,16 @@
 use allocdb_core::command::{ClientRequest, Command};
 use allocdb_core::config::Config;
 use allocdb_core::ids::{ClientId, HolderId, OperationId, ResourceId, Slot};
+use allocdb_core::recovery::RecoveryError;
+use allocdb_core::wal::{DecodeError, ScanStopReason};
+use allocdb_core::wal_file::{WalFile, WalFileError};
 use allocdb_core::{ReservationState, ResourceState};
 
 use crate::engine::{
-    CheckpointError, CrashPlan, CrashPoint, EngineConfig, PersistFailurePhase, RecoverEngineError,
-    RecoveryStartupKind, SubmissionError,
+    CheckpointError, CrashPlan, CrashPoint, EngineConfig, RecoverEngineError, RecoveryStartupKind,
+    SubmissionError,
 };
-use crate::simulation::SimulationHarness;
+use crate::simulation::{SimulationHarness, StorageFault};
 
 fn core_config() -> Config {
     Config {
@@ -279,7 +282,7 @@ fn simulated_slot_driver_handles_expiration_restart_path() {
         ReservationState::Reserved
     );
 
-    harness.inject_next_persist_failure(PersistFailurePhase::AfterAppend);
+    harness.inject_storage_fault(StorageFault::SyncFailure);
     let error = harness.tick_expirations().unwrap_err();
     assert!(matches!(error, SubmissionError::WalFile(_)));
     assert!(!harness.metrics().accepting_writes);
@@ -325,17 +328,127 @@ fn simulated_slot_driver_handles_expiration_restart_path() {
 }
 
 #[test]
-fn harness_submit_propagates_persist_failure_for_negative_path_tests() {
+fn harness_storage_fault_append_failure_halts_engine_for_negative_path_tests() {
     let mut harness =
         SimulationHarness::new("persist-failure", 0x99, core_config(), engine_config()).unwrap();
 
     harness.advance_to(Slot(1));
-    harness.inject_next_persist_failure(PersistFailurePhase::BeforeAppend);
+    harness.inject_storage_fault(StorageFault::AppendFailure);
 
     let error = harness.submit(create(11, 1)).unwrap_err();
 
     assert!(matches!(error, SubmissionError::WalFile(_)));
     assert!(!harness.metrics().accepting_writes);
+}
+
+#[test]
+fn simulated_sync_failure_recovers_retryable_write_from_real_wal() {
+    let mut harness = SimulationHarness::new(
+        "sync-failure-recovery",
+        0x155,
+        core_config(),
+        engine_config(),
+    )
+    .unwrap();
+
+    harness.advance_to(Slot(1));
+    harness.inject_storage_fault(StorageFault::SyncFailure);
+
+    let error = harness.submit(create(11, 1)).unwrap_err();
+
+    assert!(matches!(error, SubmissionError::WalFile(_)));
+    assert!(!harness.metrics().accepting_writes);
+
+    let recovered = harness.restart().unwrap();
+    assert_eq!(
+        recovered.recovery.startup_kind,
+        RecoveryStartupKind::WalOnly
+    );
+    assert_eq!(recovered.recovery.replayed_wal_frame_count, 1);
+    assert_eq!(
+        recovered
+            .recovery
+            .replayed_wal_last_lsn
+            .map(allocdb_core::Lsn::get),
+        Some(1)
+    );
+    assert!(harness.engine().db().resource(ResourceId(11)).is_some());
+
+    let retry = harness.submit(create(11, 1)).unwrap();
+    assert!(retry.from_retry_cache);
+    assert_eq!(retry.applied_lsn.get(), 1);
+}
+
+#[test]
+fn simulated_torn_tail_recovers_from_snapshot_and_retries_once() {
+    let mut harness =
+        SimulationHarness::new("torn-tail-recovery", 0x166, core_config(), engine_config())
+            .unwrap();
+
+    harness.advance_to(Slot(1));
+    harness.submit(create(11, 1)).unwrap();
+    harness.checkpoint().unwrap();
+
+    harness.advance_to(Slot(2));
+    harness.submit(create(12, 2)).unwrap();
+    harness.inject_storage_fault(StorageFault::TornLastFrameTail { truncate_bytes: 2 });
+
+    let recovered = harness.restart().unwrap();
+
+    assert_eq!(
+        recovered.recovery.startup_kind,
+        RecoveryStartupKind::SnapshotOnly
+    );
+    assert_eq!(
+        recovered
+            .recovery
+            .loaded_snapshot_lsn
+            .map(allocdb_core::Lsn::get),
+        Some(1)
+    );
+    assert_eq!(recovered.recovery.replayed_wal_frame_count, 0);
+    assert!(harness.engine().db().resource(ResourceId(11)).is_some());
+    assert!(harness.engine().db().resource(ResourceId(12)).is_none());
+    let wal = WalFile::open(
+        harness.engine().wal_path(),
+        engine_config().max_command_bytes,
+    )
+    .unwrap();
+    let recovered_wal = wal.recover().unwrap();
+    assert_eq!(
+        recovered_wal.scan_result.stop_reason,
+        ScanStopReason::CleanEof
+    );
+
+    let retried = harness.submit(create(12, 2)).unwrap();
+    assert!(!retried.from_retry_cache);
+    assert_eq!(retried.applied_lsn.get(), 2);
+    assert!(harness.engine().db().resource(ResourceId(12)).is_some());
+}
+
+#[test]
+fn simulated_checksum_corruption_fails_closed_during_restart() {
+    let mut harness =
+        SimulationHarness::new("checksum-corruption", 0x177, core_config(), engine_config())
+            .unwrap();
+
+    harness.advance_to(Slot(1));
+    harness.submit(create(11, 1)).unwrap();
+    harness.checkpoint().unwrap();
+
+    harness.advance_to(Slot(2));
+    harness.submit(create(12, 2)).unwrap();
+    harness.inject_storage_fault(StorageFault::CorruptLastFrameChecksum);
+
+    let error = harness.restart().unwrap_err();
+
+    assert!(matches!(
+        error,
+        RecoverEngineError::Recovery(RecoveryError::WalFile(WalFileError::Corruption {
+            error: DecodeError::InvalidChecksum,
+            ..
+        }))
+    ));
 }
 
 #[test]

--- a/docs/status.md
+++ b/docs/status.md
@@ -29,7 +29,9 @@
     sequencing paths, including deterministic pre-commit overflow rejection for request slots,
     fail-closed replay rejection for overflowed WAL commands, restart coverage for post-sync
     submit replay and replay-interrupted recovery, and explicit `next_lsn` exhaustion handling
-    after `u64::MAX`
+    after `u64::MAX`, plus deterministic storage-fault injection for append failures,
+    sync-failure ambiguity, checksum-mismatch fail-closed recovery, and torn-tail truncation over
+    the real WAL restart path
 
 ## What Exists
 
@@ -95,10 +97,14 @@
   - seeded same-slot ready-set scheduling with reproducible transcripts
   - seeded one-shot crash plans over named client-submit, internal-apply, checkpoint, and
     recovery boundaries
-  - checkpoint, restart, and injected persist-failure helpers over the real `SingleNodeEngine`
+  - one-shot storage fault helpers over append failure, sync failure, checksum mismatch, and
+    torn-tail WAL mutation against real on-disk recovery
+  - checkpoint, restart, and live write-fault helpers over the real `SingleNodeEngine`
   - regression coverage for crash-selected post-sync submit replay, crash-after-snapshot-write
-    checkpoint recovery, and replay-interrupted recovery restart
+    checkpoint recovery, replay-interrupted recovery restart, sync-failure retry recovery,
+    checksum-corruption fail-closed restart, and torn-tail truncation retry
 - Validation:
+  - `cargo test -p allocdb-core wal -- --nocapture`
   - `cargo test -p allocdb-core snapshot -- --nocapture`
   - `cargo test -p allocdb-core recovery -- --nocapture`
   - `cargo test -p allocdb-core snapshot_restores_retired_lookup_watermark`
@@ -110,10 +116,10 @@
 
 ## Current Focus
 
-- `M4-T03`: extend the same seeded simulation driver with storage-fault coverage for torn writes,
-  checksum mismatch, and sync failures
-- keep the operator runbook aligned as new simulation and storage-fault evidence lands
-- keep `M4-T02` regression coverage green while broadening the fault matrix
+- `M4-T04`: extend the seeded simulation driver with reproducible schedule exploration over
+  ingress order, expiration order, and retry timing
+- keep `M4-T02` and `M4-T03` regression coverage green while broadening the schedule matrix
+- keep the operator runbook and testing notes aligned as new simulation evidence lands
 
 ## How To Check Progress
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -105,6 +105,9 @@ regression coverage in `crates/allocdb-node/src/simulation_tests.rs`. The curren
 - seeded crash plans now interrupt the real engine at client submit/apply, checkpoint, and
   recovery boundaries, with restart tests covering post-sync submit replay, snapshot-written
   before WAL rewrite, and replay-interrupted recovery
+- one-shot storage-fault helpers now cover append-failure halts, sync-failure ambiguity,
+  checksum-mismatch fail-closed recovery, and torn-tail truncation against the real WAL and
+  restart path
 
 What to reuse in follow-up tasks:
 
@@ -112,6 +115,7 @@ What to reuse in follow-up tasks:
 - explicit slot advancement under test control
 - seeded scheduling for same-slot ready work
 - seeded one-shot crash plans over real engine and recovery boundaries
+- one-shot storage-fault helpers over live WAL writes and post-crash WAL mutation
 - restart helpers that reopen from snapshot plus WAL on disk
 
 What not to promote directly:


### PR DESCRIPTION
## Summary
- add deterministic storage fault injection to the seeded simulation harness
- cover append failures, sync failures, checksum corruption, and torn-tail recovery through the real restart path
- update testing and status docs to record the new simulation evidence

## Validation
- cargo test -p allocdb-core wal -- --nocapture
- cargo test -p allocdb-core recovery -- --nocapture
- cargo test -p allocdb-node simulation -- --nocapture
- ./scripts/preflight.sh

Fixes #18
