### PR TITLE
docs: open M7 and M8 roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -248,12 +248,56 @@ Exit criteria:
 - replication work has explicit validation gates
 - quorum and failover choices are justified against the research inputs
 
+### M7: Replicated Core Prototype
+
+Goal:
+
+- implement the first real replicated AllocDB shard on top of the completed `M6` design
+
+Deliverables:
+
+- replicated node wrapper state and durable protocol metadata
+- deterministic `3`-replica in-process cluster harness
+- primary-to-backup quorum write path
+- view change and fail-closed read behavior
+- suffix catch-up, snapshot transfer, and rejoin
+- executable replicated simulation scenarios from [testing.md](./testing.md)
+
+Exit criteria:
+
+- one configured primary can replicate and commit through majority durable append
+- quorum loss and higher-view takeover fail closed instead of guessing
+- stale and recovering replicas catch up without rewriting committed history
+- replicated simulation scenarios for partition, primary crash, and rejoin run against the real
+  replicated harness
+
+### M8: External Cluster Validation
+
+Goal:
+
+- validate the replicated implementation through real processes and an external fault harness
+
+Deliverables:
+
+- multi-process local replicated cluster runner
+- local fault-control harness for process and network disruption
+- local QEMU `3`-replica plus control-node testbed
+- Jepsen harness implementing the release gate from [testing.md](./testing.md)
+
+Exit criteria:
+
+- local multi-process and QEMU-backed clusters are reproducible enough for scripted fault runs
+- Jepsen histories apply AllocDB's retry-aware interpretation for ambiguous writes
+- release-blocking invariants are enforced automatically for failover, ambiguity, stale reads, and
+  expiration safety
+- the external validation path is documented well enough to run before any replicated release
+
 ## Sequencing
 
 The minimum dependency chain is:
 
 ```text
-M0 -> M1 -> M1H -> M2 -> M3 -> M4 -> M5 -> M6
+M0 -> M1 -> M1H -> M2 -> M3 -> M4 -> M5 -> M6 -> M7 -> M8
 ```
 
 Allowed overlap:
@@ -264,6 +308,8 @@ Allowed overlap:
 - some M2 durability hardening can overlap with M1H when it does not reopen state-machine
   semantics
 - some M5 API and metrics work can start during late M3
+- some M8 cluster-runner and operator packaging work can start during late M7 when it does not
+  weaken deterministic replicated-harness coverage
 
 Not allowed:
 
@@ -280,6 +326,8 @@ Suggested review points:
 4. end of M2: durability and corruption-handling review
 5. end of M4: simulation credibility review
 6. end of M5: alpha readiness review
+7. end of M7: replicated prototype correctness review
+8. end of M8: external validation gate review
 
 ## Planning Output
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,7 +2,7 @@
 
 ## Current State
 
-- Phase: single-node v1 foundation
+- Phase: replicated implementation planning
 - Planning IDs:
   - tasks use `M#-T#`
   - spikes use `M#-S#`
@@ -15,6 +15,8 @@
   - `M4` simulation: implemented
   - `M5` single-node alpha surface: implemented
   - `M6` replication design: implemented
+  - `M7` replicated core prototype: planned
+  - `M8` external cluster validation: planned
 - Latest completed implementation chunks:
   - `4156a80` `Bootstrap AllocDB core and docs`
   - `f84a641` `Add WAL file and snapshot recovery primitives`
@@ -134,10 +136,13 @@
 
 ## Current Focus
 
-- the current roadmap queue has no open planned issues after `M6-T03`
-- if replicated implementation begins, open a new tracked milestone and keep `docs/testing.md` and
-  `docs/replication.md` authoritative for validation and protocol rules
-- keep `docs/status.md` aligned when new post-M6 work is planned
+- `M7-T01`: add replicated node state and durable protocol metadata
+- `M7-T02`: build the deterministic 3-replica cluster harness
+- `M7-T03`: implement the first quorum write path with one configured primary
+- follow with `M7-T04` through `M7-T06` for view change, rejoin, and executable replicated
+  simulation coverage
+- use `M8` for the external multi-process, QEMU, and Jepsen layers after the in-process replicated
+  prototype is credible
 
 ## How To Check Progress
 

--- a/docs/work-breakdown.md
+++ b/docs/work-breakdown.md
@@ -1059,6 +1059,223 @@ Test evidence:
 
 - design review only
 
+## M7: Replicated Core Prototype
+
+### M7-T01: Add replicated node state and durable protocol metadata
+
+Goal:
+
+- build the replica wrapper state and durable protocol metadata required by the first replicated
+  prototype
+
+Blocked by:
+
+- M6-T03
+
+Acceptance criteria:
+
+- replicated node startup has explicit durable protocol metadata
+- local validation and faulted-state entry are defined in code and tests
+- no simulator-only replica execution path is introduced
+- docs stay aligned if the persisted metadata contract changes
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
+### M7-T02: Build deterministic 3-replica cluster harness
+
+Goal:
+
+- build the deterministic in-process cluster harness for the replicated prototype
+
+Blocked by:
+
+- M7-T01
+
+Acceptance criteria:
+
+- the harness runs three real replicas without mock state-machine semantics
+- message delivery, partitioning, crash, and restart are explicit driver actions
+- the same seed and starting state reproduce the same transcript
+- docs and harness APIs stay aligned with [testing.md](./testing.md)
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
+### M7-T03: Implement quorum write path with one configured primary
+
+Goal:
+
+- implement the first majority-backed write path with one configured primary and primary-only reads
+
+Blocked by:
+
+- M7-T01
+- M7-T02
+
+Acceptance criteria:
+
+- committed write results are published only after majority durable append
+- backups do not apply entries before they are committed
+- the existing allocator executor remains the only apply path
+- tests cover normal quorum write and primary-only read behavior
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
+### M7-T04: Add view change and fail-closed reads on quorum loss
+
+Goal:
+
+- implement higher-view takeover plus fail-closed read behavior under quorum ambiguity
+
+Blocked by:
+
+- M7-T03
+
+Acceptance criteria:
+
+- a quorum-lost primary fails closed for reads and writes
+- a new primary reconstructs the latest safe committed prefix before normal mode
+- committed entries survive failover unchanged
+- tests cover primary loss, higher-view takeover, and stale-node read rejection
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
+### M7-T05: Add suffix catch-up, snapshot transfer, and rejoin
+
+Goal:
+
+- implement stale-replica catch-up and safe rejoin
+
+Blocked by:
+
+- M7-T04
+
+Acceptance criteria:
+
+- stale replicas can rejoin without rewriting committed history
+- divergent uncommitted suffix is discarded safely during catch-up
+- corrupted replicas do not vote, lead, or serve before repair
+- tests cover suffix-only catch-up, snapshot transfer, and faulted rejoin rejection
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
+### M7-T06: Promote replicated simulation scenarios into executable tests
+
+Goal:
+
+- turn the replicated simulation plan into executable regression coverage
+
+Blocked by:
+
+- M7-T05
+
+Acceptance criteria:
+
+- partition, primary-crash, and rejoin scenarios execute in the real replicated harness
+- the same seed and starting state reproduce the same replicated transcript
+- promoted tests check the invariants documented in [testing.md](./testing.md)
+- failing schedules can be replayed directly from recorded transcript data
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
+## M8: External Cluster Validation
+
+### M8-T01: Build multi-process local replicated cluster runner
+
+Goal:
+
+- build the first multi-process local cluster runner for replicated AllocDB
+
+Blocked by:
+
+- M7-T05
+
+Acceptance criteria:
+
+- a local operator can start and stop a three-replica cluster from one command surface
+- node identities and durable workspaces remain stable across restart
+- logs and control hooks are sufficient for follow-on fault injection
+- docs stay aligned with the local cluster runner usage
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
+### M8-T02: Add local fault-control harness for process and network disruption
+
+Goal:
+
+- add a local fault-control harness for process crash, restart, and network isolation
+
+Blocked by:
+
+- M8-T01
+
+Acceptance criteria:
+
+- process and network disruption are controllable through one local harness
+- the harness can isolate stale primaries and later heal the cluster
+- cluster timelines are recorded well enough for later checker and debug use
+- follow-on validation work can reuse the same fault-control surface
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
+### M8-T03: Build local QEMU replicated testbed
+
+Goal:
+
+- build the local QEMU-backed replicated cluster testbed
+
+Blocked by:
+
+- M8-T02
+
+Acceptance criteria:
+
+- the QEMU environment boots a three-replica cluster plus one control node locally
+- control hooks can isolate networks, reboot guests, and collect logs
+- the environment is repeatable enough for scripted validation runs
+- docs describe how the QEMU testbed maps to the first Jepsen gate
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
+### M8-T04: Implement Jepsen harness against QEMU-backed cluster
+
+Goal:
+
+- implement the Jepsen harness and release-blocking validation runs against the QEMU-backed cluster
+
+Blocked by:
+
+- M7-T06
+- M8-T03
+
+Acceptance criteria:
+
+- the Jepsen harness runs the documented workload families against the QEMU-backed cluster
+- ambiguous outcomes are retried and interpreted with stable `operation_id` semantics
+- the documented release blockers are enforced automatically by the analysis step
+- the external validation docs stay aligned with the implemented harness
+
+Test evidence:
+
+- `./scripts/preflight.sh`
+
 ## Suggested First Slice
 
 If implementation starts immediately, the highest-value first slice is:


### PR DESCRIPTION
## Summary
- open the post-M6 roadmap in the local planning docs with new `M7` and `M8` milestones
- align `docs/status.md` with the newly created GitHub milestone and issue queue
- document the deterministic-harness-first and QEMU/Jepsen-later execution path we selected

## Linked Issue
- issue-less planning follow-up: aligns the local docs with newly created milestones `M7` and `M8` and issues `#49` through `#58`

## Changes
- [x] add `M7 Replicated Core Prototype` and `M8 External Cluster Validation` to `docs/roadmap.md`
- [x] add concrete `M7-T01` through `M8-T04` tasks to `docs/work-breakdown.md`
- [x] update `docs/status.md` current phase and focus so the repo no longer points at a completed queue

## Validation
- [x] `scripts/preflight.sh`
- [ ] narrower targeted commands added when they materially strengthen confidence

## Docs
- [x] docs updated if behavior, invariants, failure modes, or operator semantics changed

## CodeRabbit Triage
- [ ] CodeRabbit status completed
- [ ] requested `@coderabbitai summary` if no visible review comment or thread appeared
- [ ] applied relevant correctness, safety, recovery, testing, and docs suggestions
- [ ] documented any intentionally rejected suggestions
