### PR TITLE
feat(replication): add quorum write path

### DIFF
--- a/crates/allocdb-node/src/engine.rs
+++ b/crates/allocdb-node/src/engine.rs
@@ -588,6 +588,27 @@ impl SingleNodeEngine {
         self.enqueue_validated(request_slot, request, encoded.to_vec())
     }
 
+    /// Validates one encoded client request against the current engine bounds without enqueuing or
+    /// applying it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SubmissionError`] if decoding fails, the payload is oversized, the engine is
+    /// halted, or the request slot would overflow the allocator's bounded windows.
+    pub fn validate_encoded_submission(
+        &self,
+        request_slot: Slot,
+        encoded: &[u8],
+    ) -> Result<(), SubmissionError> {
+        if !self.accepting_writes {
+            return Err(SubmissionError::EngineHalted);
+        }
+
+        self.validate_bytes(encoded)?;
+        let request = decode_client_request(encoded).map_err(SubmissionError::InvalidRequest)?;
+        self.validate_client_request_slot(request_slot, request.command)
+    }
+
     /// Processes one queued submission by assigning an LSN, appending it to the WAL, syncing, and
     /// applying through the live allocator path.
     ///

--- a/crates/allocdb-node/src/lib.rs
+++ b/crates/allocdb-node/src/lib.rs
@@ -19,8 +19,9 @@ pub use engine::{
     SubmissionErrorCategory, SubmissionResult,
 };
 pub use replica::{
-    DurableVote, RecoverReplicaError, ReplicaFault, ReplicaFaultReason, ReplicaId, ReplicaIdentity,
-    ReplicaMetadata, ReplicaMetadataDecodeError, ReplicaMetadataFile, ReplicaMetadataFileError,
-    ReplicaMetadataLoadError, ReplicaNode, ReplicaNodeStatus, ReplicaOpenError, ReplicaPaths,
-    ReplicaRole, ReplicaStartupValidationError,
+    DurableVote, NotPrimaryReadError, RecoverReplicaError, ReplicaFault, ReplicaFaultReason,
+    ReplicaId, ReplicaIdentity, ReplicaMetadata, ReplicaMetadataDecodeError, ReplicaMetadataFile,
+    ReplicaMetadataFileError, ReplicaMetadataLoadError, ReplicaNode, ReplicaNodeStatus,
+    ReplicaOpenError, ReplicaPaths, ReplicaPreparedEntry, ReplicaProtocolError, ReplicaRole,
+    ReplicaStartupValidationError,
 };

--- a/crates/allocdb-node/src/replica.rs
+++ b/crates/allocdb-node/src/replica.rs
@@ -1,12 +1,16 @@
+use std::collections::BTreeMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 
 use allocdb_core::config::Config;
-use allocdb_core::ids::Lsn;
+use allocdb_core::ids::{Lsn, Slot};
 use log::{error, info, warn};
 
-use crate::engine::{EngineConfig, EngineOpenError, RecoverEngineError, SingleNodeEngine};
+use crate::engine::{
+    EngineConfig, EngineOpenError, ReadError, RecoverEngineError, SingleNodeEngine,
+    SubmissionError, SubmissionResult,
+};
 
 #[cfg(all(test, unix))]
 #[path = "replica_tests.rs"]
@@ -19,6 +23,8 @@ mod non_unix_tests;
 const MAX_REPLICA_METADATA_BYTES: u64 = 256;
 const REPLICA_METADATA_MAGIC: [u8; 4] = *b"RPLM";
 const REPLICA_METADATA_VERSION: u8 = 1;
+const REPLICA_PREPARE_LOG_MAGIC: [u8; 4] = *b"RPLP";
+const REPLICA_PREPARE_LOG_VERSION: u8 = 1;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ReplicaId(pub u64);
@@ -213,6 +219,14 @@ impl ReplicaPaths {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReplicaPreparedEntry {
+    pub view: u64,
+    pub lsn: Lsn,
+    pub request_slot: Slot,
+    pub payload: Vec<u8>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ReplicaMetadataDecodeError {
     BufferTooShort,
@@ -347,6 +361,64 @@ impl From<ReplicaMetadataFileError> for RecoverReplicaError {
 }
 
 #[derive(Debug)]
+pub enum ReplicaProtocolError {
+    Inactive(ReplicaNodeStatus),
+    UnsupportedNormalRole(ReplicaRole),
+    RoleMismatch {
+        expected: ReplicaRole,
+        found: ReplicaRole,
+    },
+    ViewRegression {
+        current_view: u64,
+        requested_view: u64,
+    },
+    ViewMismatch {
+        expected: u64,
+        found: u64,
+    },
+    PrepareLsnExhausted {
+        last_lsn: Lsn,
+    },
+    PrepareOrderMismatch {
+        expected_lsn: Lsn,
+        found_lsn: Lsn,
+    },
+    PreparedEntryConflict {
+        lsn: Lsn,
+    },
+    MissingPreparedEntry {
+        lsn: Lsn,
+    },
+    PrepareStorage(std::io::ErrorKind),
+    MetadataFile(ReplicaMetadataFileError),
+    Submission(SubmissionError),
+    AppliedLsnMismatch {
+        expected: Lsn,
+        found: Lsn,
+    },
+    Read(NotPrimaryReadError),
+}
+
+impl From<ReplicaMetadataFileError> for ReplicaProtocolError {
+    fn from(error: ReplicaMetadataFileError) -> Self {
+        Self::MetadataFile(error)
+    }
+}
+
+impl From<SubmissionError> for ReplicaProtocolError {
+    fn from(error: SubmissionError) -> Self {
+        Self::Submission(error)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NotPrimaryReadError {
+    ReplicaCrashed,
+    Role(ReplicaRole),
+    Fence(ReadError),
+}
+
+#[derive(Debug)]
 pub struct ReplicaMetadataFile {
     path: PathBuf,
 }
@@ -435,9 +507,41 @@ impl ReplicaMetadataFile {
 }
 
 #[derive(Debug)]
+struct ReplicaPrepareLogFile {
+    path: PathBuf,
+}
+
+impl ReplicaPrepareLogFile {
+    fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    fn write_entries(
+        &self,
+        entries: &BTreeMap<u64, ReplicaPreparedEntry>,
+    ) -> Result<(), std::io::Error> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let temp_path = metadata_temp_path(&self.path);
+        let mut file = File::create(&temp_path)?;
+        file.write_all(&encode_prepare_log(entries))?;
+        file.sync_all()?;
+        drop(file);
+
+        replace_file_durably(&temp_path, &self.path)
+    }
+}
+
+#[derive(Debug)]
 pub struct ReplicaNode {
     metadata: ReplicaMetadata,
     metadata_file: ReplicaMetadataFile,
+    prepare_log_file: ReplicaPrepareLogFile,
+    prepared_entries: BTreeMap<u64, ReplicaPreparedEntry>,
     paths: ReplicaPaths,
     status: ReplicaNodeStatus,
     engine: Option<SingleNodeEngine>,
@@ -611,6 +715,264 @@ impl ReplicaNode {
         self.metadata_file.write_metadata(&self.metadata)
     }
 
+    #[must_use]
+    pub fn prepared_entry(&self, lsn: Lsn) -> Option<&ReplicaPreparedEntry> {
+        self.prepared_entries.get(&lsn.get())
+    }
+
+    #[must_use]
+    pub fn prepared_len(&self) -> usize {
+        self.prepared_entries.len()
+    }
+
+    #[must_use]
+    pub fn prepare_log_path(&self) -> &Path {
+        &self.prepare_log_file.path
+    }
+
+    /// Moves one active replica into normal mode for the provided view.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReplicaProtocolError`] if the replica is faulted, the requested role is not
+    /// `primary` or `backup`, the view would move backwards, or the updated metadata cannot be
+    /// persisted durably.
+    pub fn configure_normal_role(
+        &mut self,
+        current_view: u64,
+        role: ReplicaRole,
+    ) -> Result<(), ReplicaProtocolError> {
+        self.ensure_active()?;
+        if !matches!(role, ReplicaRole::Primary | ReplicaRole::Backup) {
+            return Err(ReplicaProtocolError::UnsupportedNormalRole(role));
+        }
+        if current_view < self.metadata.current_view {
+            return Err(ReplicaProtocolError::ViewRegression {
+                current_view: self.metadata.current_view,
+                requested_view: current_view,
+            });
+        }
+
+        self.metadata.current_view = current_view;
+        self.metadata.role = role;
+        self.metadata.last_normal_view = Some(current_view);
+        self.metadata.durable_vote = None;
+        self.persist_metadata()?;
+        Ok(())
+    }
+
+    /// Validates and durably prepares one client request on the current primary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReplicaProtocolError`] if the replica is not an active primary, if the next
+    /// prepared LSN would overflow, if the payload fails the existing single-node ingress
+    /// validation path, or if the prepared-entry sidecar cannot be persisted.
+    pub fn prepare_client_request(
+        &mut self,
+        request_slot: Slot,
+        payload: &[u8],
+    ) -> Result<ReplicaPreparedEntry, ReplicaProtocolError> {
+        self.require_role(ReplicaRole::Primary)?;
+        let next_lsn = self.next_prepared_lsn()?;
+        let entry = ReplicaPreparedEntry {
+            view: self.metadata.current_view,
+            lsn: next_lsn,
+            request_slot,
+            payload: payload.to_vec(),
+        };
+        self.append_prepared_entry(entry.clone())?;
+        Ok(entry)
+    }
+
+    /// Durably appends one already-assigned prepared entry without applying it to allocator state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReplicaProtocolError`] if the replica is not in normal mode, if the entry view or
+    /// LSN order is invalid, if a different prepared payload already occupies the same LSN, if the
+    /// payload fails single-node ingress validation, or if the sidecar write fails.
+    pub fn append_prepared_entry(
+        &mut self,
+        entry: ReplicaPreparedEntry,
+    ) -> Result<(), ReplicaProtocolError> {
+        self.ensure_normal_role()?;
+        if entry.view != self.metadata.current_view {
+            return Err(ReplicaProtocolError::ViewMismatch {
+                expected: self.metadata.current_view,
+                found: entry.view,
+            });
+        }
+        if let Some(existing) = self.prepared_entries.get(&entry.lsn.get()) {
+            return if existing == &entry {
+                Ok(())
+            } else {
+                Err(ReplicaProtocolError::PreparedEntryConflict { lsn: entry.lsn })
+            };
+        }
+
+        let expected_lsn = self.next_prepared_lsn()?;
+        if entry.lsn != expected_lsn {
+            return Err(ReplicaProtocolError::PrepareOrderMismatch {
+                expected_lsn,
+                found_lsn: entry.lsn,
+            });
+        }
+
+        self.engine_mut()?
+            .validate_encoded_submission(entry.request_slot, &entry.payload)?;
+        self.prepared_entries.insert(entry.lsn.get(), entry);
+        self.persist_prepared_entries()
+    }
+
+    /// Applies prepared entries through the existing single-node executor up to one committed LSN.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ReplicaProtocolError`] if the replica is not in normal mode, if any committed LSN
+    /// is missing from the prepared buffer, if the entry view no longer matches the local view, if
+    /// the single-node executor rejects the payload, if the applied LSN diverges from the prepared
+    /// position, or if the updated metadata / prepared-entry sidecar cannot be persisted.
+    pub fn commit_prepared_through(
+        &mut self,
+        commit_lsn: Lsn,
+    ) -> Result<Option<SubmissionResult>, ReplicaProtocolError> {
+        self.ensure_normal_role()?;
+        let first_pending = self
+            .metadata
+            .commit_lsn
+            .and_then(|lsn| lsn.get().checked_add(1))
+            .unwrap_or(1);
+        if commit_lsn.get() < first_pending {
+            return Ok(None);
+        }
+
+        let entries = (first_pending..=commit_lsn.get())
+            .map(|lsn| {
+                self.prepared_entries
+                    .get(&lsn)
+                    .cloned()
+                    .ok_or(ReplicaProtocolError::MissingPreparedEntry { lsn: Lsn(lsn) })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut last_result = None;
+        for entry in &entries {
+            if entry.view != self.metadata.current_view {
+                return Err(ReplicaProtocolError::ViewMismatch {
+                    expected: self.metadata.current_view,
+                    found: entry.view,
+                });
+            }
+            let result = self
+                .engine_mut()?
+                .submit_encoded(entry.request_slot, &entry.payload)?;
+            if result.applied_lsn != entry.lsn {
+                return Err(ReplicaProtocolError::AppliedLsnMismatch {
+                    expected: entry.lsn,
+                    found: result.applied_lsn,
+                });
+            }
+            self.metadata.commit_lsn = Some(entry.lsn);
+            self.metadata.active_snapshot_lsn = self
+                .engine
+                .as_ref()
+                .and_then(SingleNodeEngine::active_snapshot_lsn);
+            last_result = Some(result);
+        }
+
+        for entry in &entries {
+            self.prepared_entries.remove(&entry.lsn.get());
+        }
+
+        self.persist_prepared_entries()?;
+        self.persist_metadata()?;
+        Ok(last_result)
+    }
+
+    /// Enforces the first replicated-release read rule: only the current primary may serve reads.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NotPrimaryReadError`] if the replica is faulted, is not currently the primary, or
+    /// has not yet applied the required committed LSN locally.
+    pub fn enforce_primary_read(&self, required_lsn: Lsn) -> Result<(), NotPrimaryReadError> {
+        match self.status {
+            ReplicaNodeStatus::Active => {}
+            ReplicaNodeStatus::Faulted(_) => return Err(NotPrimaryReadError::ReplicaCrashed),
+        }
+
+        if self.metadata.role != ReplicaRole::Primary {
+            return Err(NotPrimaryReadError::Role(self.metadata.role));
+        }
+
+        self.engine
+            .as_ref()
+            .ok_or(NotPrimaryReadError::ReplicaCrashed)?
+            .enforce_read_fence(required_lsn)
+            .map_err(NotPrimaryReadError::Fence)
+    }
+
+    fn ensure_active(&self) -> Result<(), ReplicaProtocolError> {
+        match self.status {
+            ReplicaNodeStatus::Active => Ok(()),
+            status @ ReplicaNodeStatus::Faulted(_) => Err(ReplicaProtocolError::Inactive(status)),
+        }
+    }
+
+    fn require_role(&self, expected: ReplicaRole) -> Result<(), ReplicaProtocolError> {
+        self.ensure_active()?;
+        if self.metadata.role == expected {
+            Ok(())
+        } else {
+            Err(ReplicaProtocolError::RoleMismatch {
+                expected,
+                found: self.metadata.role,
+            })
+        }
+    }
+
+    fn ensure_normal_role(&self) -> Result<(), ReplicaProtocolError> {
+        self.ensure_active()?;
+        match self.metadata.role {
+            ReplicaRole::Primary | ReplicaRole::Backup => Ok(()),
+            found => Err(ReplicaProtocolError::RoleMismatch {
+                expected: ReplicaRole::Backup,
+                found,
+            }),
+        }
+    }
+
+    fn next_prepared_lsn(&self) -> Result<Lsn, ReplicaProtocolError> {
+        let last_lsn = self
+            .prepared_entries
+            .last_key_value()
+            .map(|(lsn, _)| Lsn(*lsn))
+            .or(self.metadata.commit_lsn);
+        match last_lsn {
+            Some(last_lsn) => last_lsn
+                .get()
+                .checked_add(1)
+                .map(Lsn)
+                .ok_or(ReplicaProtocolError::PrepareLsnExhausted { last_lsn }),
+            None => Ok(Lsn(1)),
+        }
+    }
+
+    fn persist_prepared_entries(&self) -> Result<(), ReplicaProtocolError> {
+        self.prepare_log_file
+            .write_entries(&self.prepared_entries)
+            .map_err(|error| ReplicaProtocolError::PrepareStorage(error.kind()))
+    }
+
+    fn engine_mut(&mut self) -> Result<&mut SingleNodeEngine, ReplicaProtocolError> {
+        self.ensure_active()?;
+        Ok(self
+            .engine
+            .as_mut()
+            .expect("active replica must keep one live engine"))
+    }
+
     fn active(
         metadata: ReplicaMetadata,
         metadata_file: ReplicaMetadataFile,
@@ -620,6 +982,8 @@ impl ReplicaNode {
         Self {
             metadata,
             metadata_file,
+            prepare_log_file: ReplicaPrepareLogFile::new(prepare_log_path(&paths.metadata_path)),
+            prepared_entries: BTreeMap::new(),
             paths,
             status: ReplicaNodeStatus::Active,
             engine: Some(engine),
@@ -635,6 +999,8 @@ impl ReplicaNode {
         Self {
             metadata,
             metadata_file,
+            prepare_log_file: ReplicaPrepareLogFile::new(prepare_log_path(&paths.metadata_path)),
+            prepared_entries: BTreeMap::new(),
             paths,
             status: ReplicaNodeStatus::Faulted(ReplicaFault { reason }),
             engine: None,
@@ -707,6 +1073,49 @@ fn validate_active_metadata(
             engine.active_snapshot_lsn(),
         )
         .map_err(ReplicaFaultReason::Validation)
+}
+
+pub(crate) fn prepare_log_path(metadata_path: &Path) -> PathBuf {
+    let mut path = metadata_path.to_path_buf();
+    let extension = path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map_or_else(|| "prepare".to_owned(), |value| format!("{value}.prepare"));
+    path.set_extension(extension);
+    path
+}
+
+fn metadata_temp_path(path: &Path) -> PathBuf {
+    let mut temp_path = path.to_path_buf();
+    let extension = temp_path
+        .extension()
+        .and_then(|value| value.to_str())
+        .map_or_else(|| "tmp".to_owned(), |value| format!("{value}.tmp"));
+    temp_path.set_extension(extension);
+    temp_path
+}
+
+fn encode_prepare_log(entries: &BTreeMap<u64, ReplicaPreparedEntry>) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&REPLICA_PREPARE_LOG_MAGIC);
+    bytes.push(REPLICA_PREPARE_LOG_VERSION);
+    bytes.extend_from_slice(
+        &u64::try_from(entries.len())
+            .expect("prepared entry count must fit u64")
+            .to_le_bytes(),
+    );
+    for entry in entries.values() {
+        bytes.extend_from_slice(&entry.view.to_le_bytes());
+        bytes.extend_from_slice(&entry.lsn.get().to_le_bytes());
+        bytes.extend_from_slice(&entry.request_slot.get().to_le_bytes());
+        bytes.extend_from_slice(
+            &u64::try_from(entry.payload.len())
+                .expect("prepared payload length must fit u64")
+                .to_le_bytes(),
+        );
+        bytes.extend_from_slice(&entry.payload);
+    }
+    bytes
 }
 
 fn encode_replica_metadata(metadata: &ReplicaMetadata) -> Vec<u8> {

--- a/crates/allocdb-node/src/replica_tests.rs
+++ b/crates/allocdb-node/src/replica_tests.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use allocdb_core::command::{ClientRequest, Command};
+use allocdb_core::command_codec::encode_client_request;
 use allocdb_core::config::Config;
 use allocdb_core::ids::{ClientId, HolderId, Lsn, OperationId, ResourceId, Slot};
 
@@ -11,7 +12,7 @@ use crate::replica::{
     DurableVote, ReplicaFaultReason, ReplicaId, ReplicaIdentity, ReplicaMetadata,
     ReplicaMetadataDecodeError, ReplicaMetadataFile, ReplicaMetadataFileError,
     ReplicaMetadataLoadError, ReplicaNode, ReplicaNodeStatus, ReplicaPaths, ReplicaRole,
-    ReplicaStartupValidationError,
+    ReplicaStartupValidationError, prepare_log_path,
 };
 
 fn test_path(name: &str, extension: &str) -> PathBuf {
@@ -101,6 +102,7 @@ fn cleanup(paths: &ReplicaPaths) {
     remove_if_exists(&paths.metadata_path);
     remove_if_exists(&paths.snapshot_path);
     remove_if_exists(&paths.wal_path);
+    remove_if_exists(&prepare_log_path(&paths.metadata_path));
 }
 
 fn base_metadata() -> ReplicaMetadata {
@@ -199,6 +201,49 @@ fn replica_recover_bootstraps_metadata_from_local_durable_state() {
     assert_eq!(node.metadata().commit_lsn, Some(Lsn(2)));
     assert_eq!(node.metadata().active_snapshot_lsn, Some(Lsn(2)));
     assert!(node.engine().is_some());
+
+    cleanup(&paths);
+}
+
+#[test]
+fn replica_prepare_and_commit_keep_apply_gated_by_commit() {
+    let paths = ReplicaPaths::new(
+        metadata_path("prepare-commit"),
+        snapshot_path("prepare-commit"),
+        wal_path("prepare-commit"),
+    );
+    let mut node =
+        ReplicaNode::open(core_config(), engine_config(), identity(), paths.clone()).unwrap();
+    node.configure_normal_role(1, ReplicaRole::Primary).unwrap();
+
+    let payload = encode_client_request(create(11, 1));
+    let entry = node.prepare_client_request(Slot(1), &payload).unwrap();
+
+    assert_eq!(entry.view, 1);
+    assert_eq!(entry.lsn, Lsn(1));
+    assert_eq!(node.prepared_len(), 1);
+    assert_eq!(node.metadata().commit_lsn, None);
+    assert_eq!(node.engine().unwrap().db().last_applied_lsn(), None);
+    assert!(fs::metadata(node.prepare_log_path()).is_ok());
+
+    let committed = node
+        .commit_prepared_through(entry.lsn)
+        .unwrap()
+        .expect("commit should publish one result");
+    assert_eq!(committed.applied_lsn, entry.lsn);
+    assert_eq!(node.prepared_len(), 0);
+    assert_eq!(node.metadata().commit_lsn, Some(entry.lsn));
+    assert_eq!(
+        node.engine().unwrap().db().last_applied_lsn(),
+        Some(entry.lsn)
+    );
+    assert!(
+        node.engine()
+            .unwrap()
+            .db()
+            .resource(ResourceId(11))
+            .is_some()
+    );
 
     cleanup(&paths);
 }

--- a/crates/allocdb-node/src/replicated_simulation.rs
+++ b/crates/allocdb-node/src/replicated_simulation.rs
@@ -1,16 +1,18 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use allocdb_core::config::Config;
-use allocdb_core::ids::{Lsn, Slot};
+use allocdb_core::ids::{Lsn, ResourceId, Slot};
+use allocdb_core::state_machine::ResourceRecord;
 use log::{debug, info, warn};
 
-use crate::engine::EngineConfig;
+use crate::engine::{EngineConfig, SubmissionResult};
 use crate::replica::{
-    RecoverReplicaError, ReplicaId, ReplicaIdentity, ReplicaNode, ReplicaNodeStatus,
-    ReplicaOpenError, ReplicaPaths, ReplicaRole,
+    NotPrimaryReadError, RecoverReplicaError, ReplicaId, ReplicaIdentity, ReplicaNode,
+    ReplicaNodeStatus, ReplicaOpenError, ReplicaPaths, ReplicaPreparedEntry, ReplicaProtocolError,
+    ReplicaRole, prepare_log_path,
 };
 use crate::simulation::{SimulatedSlotDriver, simulation_workspace_path};
 
@@ -44,11 +46,29 @@ pub(crate) struct ReplicaObservation {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum ProtocolMessage {
+    Opaque,
+    Prepare {
+        entry: ReplicaPreparedEntry,
+    },
+    PrepareAck {
+        view: u64,
+        lsn: Lsn,
+        from: ReplicaId,
+    },
+    Commit {
+        view: u64,
+        commit_lsn: Lsn,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct QueuedProtocolMessage {
     pub message_id: u64,
-    pub label: &'static str,
+    pub label: String,
     pub from: ReplicaId,
     pub to: ReplicaId,
+    pub payload: ProtocolMessage,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -125,12 +145,19 @@ pub(crate) struct ReplicatedScheduleObservation {
 pub(crate) enum ReplicatedSimulationError {
     OpenReplica(ReplicaOpenError),
     RecoverReplica(RecoverReplicaError),
+    Protocol(ReplicaProtocolError),
+    Read(NotPrimaryReadError),
     UnknownReplica(ReplicaId),
+    NotConfiguredPrimary {
+        expected: Option<ReplicaId>,
+        found: ReplicaId,
+    },
+    PendingCommitNotFound(Lsn),
     ReplicaAlreadyCrashed(ReplicaId),
     ReplicaAlreadyRunning(ReplicaId),
-    MessageNotFound(&'static str),
+    MessageNotFound(String),
     MessageDeliveryBlocked {
-        label: &'static str,
+        label: String,
         from: ClusterEndpoint,
         to: ClusterEndpoint,
     },
@@ -143,8 +170,23 @@ impl fmt::Display for ReplicatedSimulationError {
             Self::RecoverReplica(error) => {
                 write!(formatter, "failed to recover replica: {error:?}")
             }
+            Self::Protocol(error) => write!(formatter, "replica protocol error: {error:?}"),
+            Self::Read(error) => write!(formatter, "replica read error: {error:?}"),
             Self::UnknownReplica(replica_id) => {
                 write!(formatter, "unknown replica: {}", replica_id.get())
+            }
+            Self::NotConfiguredPrimary { expected, found } => write!(
+                formatter,
+                "replica {} is not the configured primary {:?}",
+                found.get(),
+                expected.map(ReplicaId::get)
+            ),
+            Self::PendingCommitNotFound(lsn) => {
+                write!(
+                    formatter,
+                    "pending primary commit not found for lsn {}",
+                    lsn.get()
+                )
             }
             Self::ReplicaAlreadyCrashed(replica_id) => {
                 write!(formatter, "replica {} is already crashed", replica_id.get())
@@ -164,6 +206,18 @@ impl fmt::Display for ReplicatedSimulationError {
 }
 
 impl std::error::Error for ReplicatedSimulationError {}
+
+impl From<ReplicaProtocolError> for ReplicatedSimulationError {
+    fn from(error: ReplicaProtocolError) -> Self {
+        Self::Protocol(error)
+    }
+}
+
+impl From<NotPrimaryReadError> for ReplicatedSimulationError {
+    fn from(error: NotPrimaryReadError) -> Self {
+        Self::Read(error)
+    }
+}
 
 #[derive(Debug)]
 struct HarnessReplica {
@@ -201,6 +255,14 @@ struct ResolvedReplicatedAction {
 }
 
 #[derive(Debug)]
+struct PendingPrimaryCommit {
+    primary: ReplicaId,
+    entry: ReplicaPreparedEntry,
+    acked_replicas: BTreeSet<u64>,
+    committed: bool,
+}
+
+#[derive(Debug)]
 pub(crate) struct ReplicatedSimulationHarness {
     slot_driver: SimulatedSlotDriver,
     core_config: Config,
@@ -208,6 +270,9 @@ pub(crate) struct ReplicatedSimulationHarness {
     replicas: Vec<HarnessReplica>,
     connectivity: ConnectivityMatrix,
     pending_messages: Vec<QueuedProtocolMessage>,
+    configured_primary: Option<ReplicaId>,
+    pending_commits: BTreeMap<u64, PendingPrimaryCommit>,
+    published_results: BTreeMap<u64, SubmissionResult>,
     next_message_id: u64,
 }
 
@@ -251,6 +316,9 @@ impl ReplicatedSimulationHarness {
             replicas,
             connectivity: ConnectivityMatrix::fully_connected(),
             pending_messages: Vec::new(),
+            configured_primary: None,
+            pending_commits: BTreeMap::new(),
+            published_results: BTreeMap::new(),
             next_message_id: 1,
         })
     }
@@ -306,6 +374,101 @@ impl ReplicatedSimulationHarness {
         &self.pending_messages
     }
 
+    pub(crate) fn configure_primary(
+        &mut self,
+        replica_id: ReplicaId,
+        view: u64,
+    ) -> Result<(), ReplicatedSimulationError> {
+        for index in 0..self.replicas.len() {
+            let current_replica_id = self.replicas[index].identity.replica_id;
+            let role = if self.replicas[index].identity.replica_id == replica_id {
+                ReplicaRole::Primary
+            } else {
+                ReplicaRole::Backup
+            };
+            let node = self.replicas[index].node.as_mut().ok_or(
+                ReplicatedSimulationError::ReplicaAlreadyCrashed(current_replica_id),
+            )?;
+            node.configure_normal_role(view, role)?;
+        }
+        self.configured_primary = Some(replica_id);
+        Ok(())
+    }
+
+    pub(crate) fn client_submit(
+        &mut self,
+        primary: ReplicaId,
+        request_slot: Slot,
+        payload: &[u8],
+        label_prefix: &str,
+    ) -> Result<ReplicaPreparedEntry, ReplicatedSimulationError> {
+        if self.configured_primary != Some(primary) {
+            return Err(ReplicatedSimulationError::NotConfiguredPrimary {
+                expected: self.configured_primary,
+                found: primary,
+            });
+        }
+
+        let entry = self
+            .replica_entry_mut(primary)?
+            .node
+            .as_mut()
+            .ok_or(ReplicatedSimulationError::ReplicaAlreadyCrashed(primary))?
+            .prepare_client_request(request_slot, payload)?;
+        self.pending_commits.insert(
+            entry.lsn.get(),
+            PendingPrimaryCommit {
+                primary,
+                entry: entry.clone(),
+                acked_replicas: BTreeSet::from([primary.get()]),
+                committed: false,
+            },
+        );
+
+        let backup_ids = self
+            .replicas
+            .iter()
+            .map(|replica| replica.identity.replica_id)
+            .filter(|replica_id| *replica_id != primary)
+            .collect::<Vec<_>>();
+        for backup_id in backup_ids {
+            let message_label = format!(
+                "{label_prefix}-prepare-{}-to-{}",
+                entry.lsn.get(),
+                backup_id.get()
+            );
+            self.queue_protocol_message_with_payload(
+                primary,
+                backup_id,
+                message_label,
+                ProtocolMessage::Prepare {
+                    entry: entry.clone(),
+                },
+            )?;
+        }
+
+        Ok(entry)
+    }
+
+    pub(crate) fn published_result(&self, lsn: Lsn) -> Option<&SubmissionResult> {
+        self.published_results.get(&lsn.get())
+    }
+
+    pub(crate) fn read_resource(
+        &self,
+        replica_id: ReplicaId,
+        resource_id: ResourceId,
+        required_lsn: Option<Lsn>,
+    ) -> Result<Option<ResourceRecord>, ReplicatedSimulationError> {
+        let node = self
+            .replica(replica_id)?
+            .ok_or(ReplicatedSimulationError::ReplicaAlreadyCrashed(replica_id))?;
+        node.enforce_primary_read(required_lsn.unwrap_or(Lsn(0)))?;
+        Ok(node
+            .engine()
+            .and_then(|engine| engine.db().resource(resource_id)))
+    }
+
     pub(crate) fn connectivity_allows(
         &self,
         from: ClusterEndpoint,
@@ -334,6 +497,21 @@ impl ReplicatedSimulationHarness {
         to: ReplicaId,
         message_label: &'static str,
     ) -> Result<ReplicatedScheduleObservationKind, ReplicatedSimulationError> {
+        self.queue_protocol_message_with_payload(
+            from,
+            to,
+            message_label.to_owned(),
+            ProtocolMessage::Opaque,
+        )
+    }
+
+    fn queue_protocol_message_with_payload(
+        &mut self,
+        from: ReplicaId,
+        to: ReplicaId,
+        message_label: String,
+        payload: ProtocolMessage,
+    ) -> Result<ReplicatedScheduleObservationKind, ReplicatedSimulationError> {
         let _ = self.replica_entry(from)?;
         let _ = self.replica_entry(to)?;
         if self.replica_observation(from)?.runtime_status == ReplicaRuntimeStatus::Crashed {
@@ -350,6 +528,7 @@ impl ReplicatedSimulationHarness {
             label: message_label,
             from,
             to,
+            payload,
         };
         self.next_message_id += 1;
         self.pending_messages.push(message.clone());
@@ -367,7 +546,7 @@ impl ReplicatedSimulationHarness {
 
     pub(crate) fn deliver_protocol_message(
         &mut self,
-        message_label: &'static str,
+        message_label: &str,
     ) -> Result<ReplicatedScheduleObservationKind, ReplicatedSimulationError> {
         let index = self.pending_message_index(message_label)?;
         let message = self.pending_messages[index].clone();
@@ -375,18 +554,18 @@ impl ReplicatedSimulationHarness {
         let to = ClusterEndpoint::Replica(message.to);
         if !self.connectivity_allows(from, to)? {
             return Err(ReplicatedSimulationError::MessageDeliveryBlocked {
-                label: message_label,
+                label: message_label.to_owned(),
                 from,
                 to,
             });
         }
-
-        let recipient = self.replica_observation(message.to)?;
-        if recipient.runtime_status == ReplicaRuntimeStatus::Crashed {
+        if self.replica_observation(message.to)?.runtime_status == ReplicaRuntimeStatus::Crashed {
             return Err(ReplicatedSimulationError::ReplicaAlreadyCrashed(message.to));
         }
 
         self.pending_messages.remove(index);
+        self.apply_protocol_message(&message)?;
+        let recipient = self.replica_observation(message.to)?;
         log_protocol_message_event(
             "ProtocolMessageDelivered",
             &message,
@@ -404,7 +583,7 @@ impl ReplicatedSimulationHarness {
 
     pub(crate) fn drop_protocol_message(
         &mut self,
-        message_label: &'static str,
+        message_label: &str,
     ) -> Result<ReplicatedScheduleObservationKind, ReplicatedSimulationError> {
         let index = self.pending_message_index(message_label)?;
         let message = self.pending_messages.remove(index);
@@ -418,6 +597,120 @@ impl ReplicatedSimulationHarness {
             message,
             pending_messages: self.pending_messages.len(),
         })
+    }
+
+    fn apply_protocol_message(
+        &mut self,
+        message: &QueuedProtocolMessage,
+    ) -> Result<(), ReplicatedSimulationError> {
+        match &message.payload {
+            ProtocolMessage::Opaque => Ok(()),
+            ProtocolMessage::Prepare { entry } => {
+                self.replica_entry_mut(message.to)?
+                    .node
+                    .as_mut()
+                    .ok_or(ReplicatedSimulationError::ReplicaAlreadyCrashed(message.to))?
+                    .append_prepared_entry(entry.clone())?;
+                let ack_label = format!("{}-ack", message.label);
+                self.queue_protocol_message_with_payload(
+                    message.to,
+                    message.from,
+                    ack_label,
+                    ProtocolMessage::PrepareAck {
+                        view: entry.view,
+                        lsn: entry.lsn,
+                        from: message.to,
+                    },
+                )?;
+                Ok(())
+            }
+            ProtocolMessage::PrepareAck { view, lsn, from } => {
+                self.handle_prepare_ack(message.to, *view, *lsn, *from)
+            }
+            ProtocolMessage::Commit { view, commit_lsn } => {
+                let node = self
+                    .replica_entry_mut(message.to)?
+                    .node
+                    .as_mut()
+                    .ok_or(ReplicatedSimulationError::ReplicaAlreadyCrashed(message.to))?;
+                if node.metadata().current_view != *view {
+                    return Err(ReplicaProtocolError::ViewMismatch {
+                        expected: node.metadata().current_view,
+                        found: *view,
+                    }
+                    .into());
+                }
+                node.commit_prepared_through(*commit_lsn)?;
+                Ok(())
+            }
+        }
+    }
+
+    fn handle_prepare_ack(
+        &mut self,
+        primary: ReplicaId,
+        view: u64,
+        lsn: Lsn,
+        from: ReplicaId,
+    ) -> Result<(), ReplicatedSimulationError> {
+        let mut commit_view = None;
+        {
+            let pending = self
+                .pending_commits
+                .get_mut(&lsn.get())
+                .ok_or(ReplicatedSimulationError::PendingCommitNotFound(lsn))?;
+            if pending.primary != primary {
+                return Err(ReplicatedSimulationError::NotConfiguredPrimary {
+                    expected: Some(pending.primary),
+                    found: primary,
+                });
+            }
+            if pending.entry.view != view {
+                return Err(ReplicaProtocolError::ViewMismatch {
+                    expected: pending.entry.view,
+                    found: view,
+                }
+                .into());
+            }
+            pending.acked_replicas.insert(from.get());
+            if !pending.committed && pending.acked_replicas.len() >= majority_quorum() {
+                commit_view = Some(pending.entry.view);
+            }
+        }
+
+        if let Some(commit_view) = commit_view {
+            let result = self
+                .replica_entry_mut(primary)?
+                .node
+                .as_mut()
+                .ok_or(ReplicatedSimulationError::ReplicaAlreadyCrashed(primary))?
+                .commit_prepared_through(lsn)?
+                .expect("primary quorum commit must publish one result");
+            self.published_results.insert(lsn.get(), result);
+            if let Some(pending) = self.pending_commits.get_mut(&lsn.get()) {
+                pending.committed = true;
+            }
+            let backup_ids = self
+                .replicas
+                .iter()
+                .map(|replica| replica.identity.replica_id)
+                .filter(|replica_id| *replica_id != primary)
+                .collect::<Vec<_>>();
+            for backup_id in backup_ids {
+                let commit_label = format!("commit-{}-to-{}", lsn.get(), backup_id.get());
+                self.queue_protocol_message_with_payload(
+                    primary,
+                    backup_id,
+                    commit_label,
+                    ProtocolMessage::Commit {
+                        view: commit_view,
+                        commit_lsn: lsn,
+                    },
+                )?;
+            }
+        }
+
+        Ok(())
     }
 
     pub(crate) fn crash_replica(
@@ -579,12 +872,12 @@ impl ReplicatedSimulationHarness {
 
     fn pending_message_index(
         &self,
-        message_label: &'static str,
+        message_label: &str,
     ) -> Result<usize, ReplicatedSimulationError> {
         self.pending_messages
             .iter()
             .position(|message| message.label == message_label)
-            .ok_or(ReplicatedSimulationError::MessageNotFound(message_label))
+            .ok_or_else(|| ReplicatedSimulationError::MessageNotFound(message_label.to_owned()))
     }
 
     fn endpoint_index(
@@ -630,6 +923,7 @@ impl Drop for ReplicatedSimulationHarness {
             remove_if_exists(&replica.paths.wal_path);
             remove_if_exists(&replica.paths.snapshot_path);
             remove_if_exists(&replica.paths.metadata_path);
+            remove_if_exists(&prepare_log_path(&replica.paths.metadata_path));
             remove_if_exists(&metadata_temp_path(&replica.paths.metadata_path));
         }
     }
@@ -643,6 +937,10 @@ fn metadata_temp_path(path: &Path) -> PathBuf {
         .map_or_else(|| "tmp".to_owned(), |value| format!("{value}.tmp"));
     temp_path.set_extension(extension);
     temp_path
+}
+
+const fn majority_quorum() -> usize {
+    (REPLICA_COUNT / 2) + 1
 }
 
 fn log_protocol_message_event(

--- a/crates/allocdb-node/src/replicated_simulation_tests.rs
+++ b/crates/allocdb-node/src/replicated_simulation_tests.rs
@@ -1,10 +1,12 @@
 use std::fs;
 
+use allocdb_core::command::{ClientRequest, Command};
+use allocdb_core::command_codec::encode_client_request;
 use allocdb_core::config::Config;
-use allocdb_core::ids::Slot;
+use allocdb_core::ids::{ClientId, Lsn, OperationId, ResourceId, Slot};
 
 use crate::engine::EngineConfig;
-use crate::replica::{ReplicaId, ReplicaNodeStatus};
+use crate::replica::{NotPrimaryReadError, ReplicaId, ReplicaNodeStatus, ReplicaRole};
 use crate::replicated_simulation::{
     ClusterEndpoint, QueuedProtocolMessage, ReplicaObservation, ReplicaRuntimeStatus,
     ReplicatedScheduleAction, ReplicatedScheduleActionKind, ReplicatedScheduleObservation,
@@ -34,6 +36,16 @@ fn engine_config() -> EngineConfig {
 
 fn replica(replica_id: u64) -> ReplicaId {
     ReplicaId(replica_id)
+}
+
+fn create_payload(resource_id: u128, operation_id: u128) -> Vec<u8> {
+    encode_client_request(ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::CreateResource {
+            resource_id: ResourceId(resource_id),
+        },
+    })
 }
 
 fn queue_message(
@@ -164,6 +176,56 @@ fn delivered_message<'a>(
         } => (message, *recipient),
         other => panic!("expected delivered protocol message, got {other:?}"),
     }
+}
+
+fn primary_harness(name: &str, seed: u64) -> ReplicatedSimulationHarness {
+    let mut harness =
+        ReplicatedSimulationHarness::new(name, seed, core_config(), engine_config()).unwrap();
+    harness.configure_primary(replica(1), 1).unwrap();
+    harness
+}
+
+fn replica_last_applied_lsn(harness: &ReplicatedSimulationHarness, replica_id: u64) -> Option<Lsn> {
+    harness
+        .replica(replica(replica_id))
+        .unwrap()
+        .unwrap()
+        .engine()
+        .unwrap()
+        .db()
+        .last_applied_lsn()
+}
+
+fn replica_prepared_len(harness: &ReplicatedSimulationHarness, replica_id: u64) -> usize {
+    harness
+        .replica(replica(replica_id))
+        .unwrap()
+        .unwrap()
+        .prepared_len()
+}
+
+fn replica_has_resource(
+    harness: &ReplicatedSimulationHarness,
+    replica_id: u64,
+    resource_id: u128,
+) -> bool {
+    harness
+        .replica(replica(replica_id))
+        .unwrap()
+        .unwrap()
+        .engine()
+        .unwrap()
+        .db()
+        .resource(ResourceId(resource_id))
+        .is_some()
+}
+
+fn pending_labels(harness: &ReplicatedSimulationHarness) -> Vec<&str> {
+    harness
+        .pending_messages()
+        .iter()
+        .map(|message| message.label.as_str())
+        .collect()
 }
 
 #[test]
@@ -330,10 +392,10 @@ fn connectivity_matrix_controls_delivery_until_partition_heals() {
     assert!(matches!(
         blocked,
         ReplicatedSimulationError::MessageDeliveryBlocked {
-            label: "prepare-blocked",
+            label,
             from: ClusterEndpoint::Replica(source),
             to: ClusterEndpoint::Replica(target),
-        } if source == replica(1) && target == replica(2)
+        } if label == "prepare-blocked" && source == replica(1) && target == replica(2)
     ));
     assert_eq!(harness.pending_messages().len(), 1);
 
@@ -379,13 +441,13 @@ fn connectivity_matrix_controls_delivery_until_partition_heals() {
         .unwrap_err();
     assert!(matches!(
         missing_delivery,
-        ReplicatedSimulationError::MessageNotFound("unknown-label")
+        ReplicatedSimulationError::MessageNotFound(label) if label == "unknown-label"
     ));
 
     let missing_drop = harness.drop_protocol_message("unknown-label").unwrap_err();
     assert!(matches!(
         missing_drop,
-        ReplicatedSimulationError::MessageNotFound("unknown-label")
+        ReplicatedSimulationError::MessageNotFound(label) if label == "unknown-label"
     ));
 }
 
@@ -500,4 +562,109 @@ fn crash_and_restart_keep_replica_workspace_stable() {
         harness.replica(replica(2)).unwrap().unwrap().status(),
         ReplicaNodeStatus::Active
     );
+}
+
+#[test]
+fn quorum_write_publishes_after_majority_append_and_backups_wait_for_commit() {
+    let mut harness = primary_harness("replicated-quorum-write", 0x5a1);
+
+    let entry = harness
+        .client_submit(replica(1), Slot(1), &create_payload(11, 1), "client-create")
+        .unwrap();
+    assert_eq!(entry.view, 1);
+    assert_eq!(entry.lsn, Lsn(1));
+    assert_eq!(harness.published_result(entry.lsn), None);
+    assert_eq!(replica_prepared_len(&harness, 1), 1);
+    assert_eq!(replica_last_applied_lsn(&harness, 1), None);
+    assert_eq!(replica_last_applied_lsn(&harness, 2), None);
+    assert_eq!(replica_last_applied_lsn(&harness, 3), None);
+    assert_eq!(
+        pending_labels(&harness),
+        vec![
+            "client-create-prepare-1-to-2",
+            "client-create-prepare-1-to-3"
+        ]
+    );
+
+    harness
+        .deliver_protocol_message("client-create-prepare-1-to-2")
+        .unwrap();
+    assert_eq!(harness.published_result(entry.lsn), None);
+    assert_eq!(replica_prepared_len(&harness, 2), 1);
+    assert_eq!(replica_last_applied_lsn(&harness, 2), None);
+
+    harness
+        .deliver_protocol_message("client-create-prepare-1-to-2-ack")
+        .unwrap();
+    let committed = *harness
+        .published_result(entry.lsn)
+        .expect("primary should publish after majority append");
+    assert_eq!(committed.applied_lsn, entry.lsn);
+    assert_eq!(replica_last_applied_lsn(&harness, 1), Some(entry.lsn));
+    assert_eq!(replica_last_applied_lsn(&harness, 2), None);
+    assert_eq!(replica_last_applied_lsn(&harness, 3), None);
+    assert_eq!(replica_prepared_len(&harness, 1), 0);
+    assert_eq!(
+        pending_labels(&harness),
+        vec![
+            "client-create-prepare-1-to-3",
+            "commit-1-to-2",
+            "commit-1-to-3",
+        ]
+    );
+
+    harness.deliver_protocol_message("commit-1-to-2").unwrap();
+    assert_eq!(replica_last_applied_lsn(&harness, 2), Some(entry.lsn));
+    assert_eq!(replica_prepared_len(&harness, 2), 0);
+    assert_eq!(replica_last_applied_lsn(&harness, 3), None);
+
+    harness
+        .deliver_protocol_message("client-create-prepare-1-to-3")
+        .unwrap();
+    assert_eq!(replica_prepared_len(&harness, 3), 1);
+    assert_eq!(replica_last_applied_lsn(&harness, 3), None);
+    harness.deliver_protocol_message("commit-1-to-3").unwrap();
+    assert_eq!(replica_prepared_len(&harness, 3), 0);
+    assert_eq!(replica_last_applied_lsn(&harness, 3), Some(entry.lsn));
+    assert!(replica_has_resource(&harness, 1, 11));
+    assert!(replica_has_resource(&harness, 2, 11));
+    assert!(replica_has_resource(&harness, 3, 11));
+}
+
+#[test]
+fn reads_are_served_only_from_the_primary_after_local_commit() {
+    let mut harness = primary_harness("replicated-primary-read", 0x5a2);
+
+    let entry = harness
+        .client_submit(replica(1), Slot(1), &create_payload(21, 2), "read-create")
+        .unwrap();
+    let before_commit = harness.read_resource(replica(1), ResourceId(21), Some(entry.lsn));
+    assert!(matches!(
+        before_commit,
+        Err(ReplicatedSimulationError::Read(NotPrimaryReadError::Fence(
+            _
+        )))
+    ));
+
+    harness
+        .deliver_protocol_message("read-create-prepare-1-to-2")
+        .unwrap();
+    harness
+        .deliver_protocol_message("read-create-prepare-1-to-2-ack")
+        .unwrap();
+    harness.deliver_protocol_message("commit-1-to-2").unwrap();
+
+    let primary_read = harness
+        .read_resource(replica(1), ResourceId(21), Some(entry.lsn))
+        .unwrap()
+        .expect("primary should serve committed resource");
+    assert_eq!(primary_read.resource_id, ResourceId(21));
+
+    let backup_read = harness.read_resource(replica(2), ResourceId(21), Some(entry.lsn));
+    assert!(matches!(
+        backup_read,
+        Err(ReplicatedSimulationError::Read(NotPrimaryReadError::Role(
+            ReplicaRole::Backup
+        )))
+    ));
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -38,7 +38,10 @@
     wrapper with durable replica metadata bootstrap, restart validation, and explicit faulted-state
     entry on invalid local protocol metadata, and a deterministic three-replica harness with one
     explicit message queue, one connectivity matrix, and replayable transcripts for queued,
-    delivered, dropped, crashed, and restarted replica actions
+    delivered, dropped, crashed, and restarted replica actions, plus the first majority-backed
+    quorum write path with one configured primary, durable prepared-entry buffering, real
+    `prepare`/`prepare_ack`/`commit` queue semantics, commit publication only after majority
+    durable append, and primary-only read enforcement on locally applied committed state
 
 ## What Exists
 
@@ -102,6 +105,10 @@
   - startup bootstrap for missing metadata on both fresh-open and recover paths
   - fail-closed `faulted` state when metadata bytes are corrupt, identity is mismatched, or local
     applied/snapshot state contradicts the persisted replicated metadata
+  - configurable normal-mode `primary` and `backup` roles for one current view
+  - durable prepared-entry sidecar for pre-commit replicated client commands
+  - prepare append, commit-through, and strict primary-read guards built around the existing
+    single-node executor rather than a second apply path
 - Durability primitives:
   - WAL frame codec and recovery scan
   - file-backed WAL append, sync, recovery, and torn-tail truncation
@@ -139,6 +146,11 @@
   - explicit replica-to-replica and client-to-replica connectivity matrix under test control
   - explicit protocol-message queue plus replayable transcripts for queue, deliver, drop, crash,
     and restart actions
+  - real `prepare`, `prepare_ack`, and `commit` protocol payload delivery on that queue
+  - configured-primary client submit flow with result publication only after majority durable
+    append
+  - backup replicas that durably append prepares but do not apply allocator state until commit
+  - primary-only resource reads guarded by the existing strict-read fence after local commit
   - replica crash as loss of volatile state with restart through real `ReplicaNode::recover`
 - Validation:
   - `cargo test -p allocdb-core wal -- --nocapture`
@@ -155,11 +167,10 @@
 
 ## Current Focus
 
-- `M7-T03`: implement the first quorum write path with one configured primary
-- use the deterministic replicated harness from `M7-T02` as the execution surface for quorum
-  prepare/commit work
-- follow with `M7-T04` through `M7-T06` for view change, rejoin, and executable replicated
-  simulation coverage
+- `M7-T03` is implemented on this branch; the next execution target is `M7-T04`
+- add higher-view takeover and fail-closed read behavior when the old primary loses quorum
+- preserve the committed prefix from `M7-T03` while introducing view change and quorum-loss tests
+- follow with `M7-T05` and `M7-T06` for rejoin and executable replicated simulation coverage
 - use `M8` for the external multi-process, QEMU, and Jepsen layers after the in-process replicated
   prototype is credible
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -212,9 +212,9 @@ codebase:
 - `explore_schedule`
 
 The harness already hosts three real `ReplicaNode`s with independent durable workspaces and one
-shared seeded slot driver. Protocol payloads remain opaque labels in this milestone; `M7-T03`
-layers real primary/backup message semantics onto the same deterministic queue and transcript
-surface.
+shared seeded slot driver. `M7-T03` upgrades that queue from opaque labels to real
+`prepare`/`prepare_ack`/`commit` payloads while keeping the same deterministic delivery,
+partition, crash, and replay surface.
 
 ### Network And Failure Model In Simulation
 


### PR DESCRIPTION
## Summary

Implement the first quorum-backed replicated write path for one configured primary.

## Linked Issue

- Closes #51

## Changes

- add replica-layer normal-mode role configuration, durable prepared-entry buffering, and prepare/commit methods that keep the existing single-node executor as the only apply path
- add deterministic harness support for real `prepare`, `prepare_ack`, and `commit` protocol payloads plus configured-primary client submit and primary-only read helpers
- add regression coverage for prepare/commit gating, majority-backed result publication, backups staying unapplied before commit, and primary-only reads
- update `docs/testing.md` and `docs/status.md` to reflect the new replicated queue semantics and next milestone focus

## Validation

- [x] `./scripts/preflight.sh`
- [x] `cargo test -p allocdb-node replica -- --nocapture`
- [x] `cargo test -p allocdb-node replicated_simulation -- --nocapture`

## Docs

- [x] docs updated if behavior, invariants, failure modes, or operator semantics changed

## CodeRabbit Triage

- [ ] CodeRabbit status completed
- [ ] requested `@coderabbitai summary` if no visible review comment or thread appeared
- [ ] applied relevant correctness, safety, recovery, testing, and docs suggestions
- [ ] documented any intentionally rejected suggestions
