### PR TITLE
feat(node): extend lease transport surface for M9-T09

### DIFF
--- a/crates/allocdb-core/src/state_machine_members.rs
+++ b/crates/allocdb-core/src/state_machine_members.rs
@@ -43,6 +43,27 @@ impl AllocDb {
             .copied()
     }
 
+    #[must_use]
+    ///
+    /// # Panics
+    ///
+    /// Panics if `reservation.member_count` cannot fit `usize` on the current platform or if the
+    /// trusted core has lost one of the live member records required by `reservation`.
+    pub fn reservation_member_resource_ids(
+        &self,
+        reservation: ReservationRecord,
+    ) -> Vec<ResourceId> {
+        let mut resource_ids =
+            Vec::with_capacity(usize::try_from(reservation.member_count).expect("u32 fits usize"));
+        for member_index in 0..reservation.member_count {
+            let member = self
+                .reservation_member(reservation.reservation_id, member_index)
+                .expect("live reservation must retain all member records");
+            resource_ids.push(member.resource_id);
+        }
+        resource_ids
+    }
+
     pub(crate) fn reservation_contains_resource(
         &self,
         reservation: ReservationRecord,

--- a/crates/allocdb-node/src/api.rs
+++ b/crates/allocdb-node/src/api.rs
@@ -3,10 +3,10 @@ use allocdb_core::command_codec::{
     CommandCodecError, decode_client_request, encode_client_request,
 };
 use allocdb_core::ids::{HolderId, Lsn, ReservationId, ResourceId, Slot};
-use allocdb_core::result::CommandOutcome;
+use allocdb_core::result::ResultCode;
 use allocdb_core::{
-    ReservationLookupError, ReservationRecord, ReservationState, ResourceRecord, ResourceState,
-    SlotOverflowKind,
+    AllocDb, ReservationLookupError, ReservationRecord, ReservationState, ResourceRecord,
+    ResourceState, SlotOverflowKind,
 };
 
 use crate::engine::{
@@ -26,7 +26,7 @@ pub use codec::{ApiCodecError, decode_request, decode_response, encode_request, 
 pub enum ApiRequest {
     Submit(SubmitRequest),
     GetResource(ResourceRequest),
-    GetReservation(ReservationRequest),
+    GetLease(LeaseRequest),
     GetMetrics(MetricsRequest),
     TickExpirations(TickExpirationsRequest),
 }
@@ -63,8 +63,8 @@ pub struct ResourceRequest {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ReservationRequest {
-    pub reservation_id: ReservationId,
+pub struct LeaseRequest {
+    pub lease_id: ReservationId,
     pub current_slot: Slot,
     pub required_lsn: Option<Lsn>,
 }
@@ -83,12 +83,12 @@ pub struct TickExpirationsRequest {
 pub enum ApiResponse {
     Submit(SubmitResponse),
     GetResource(ResourceResponse),
-    GetReservation(ReservationResponse),
+    GetLease(LeaseResponse),
     GetMetrics(MetricsResponse),
     TickExpirations(TickExpirationsResponse),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SubmitResponse {
     Committed(SubmissionCommitted),
     Rejected(SubmissionFailure),
@@ -97,7 +97,10 @@ pub enum SubmitResponse {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SubmissionCommitted {
     pub applied_lsn: Lsn,
-    pub outcome: CommandOutcome,
+    pub result_code: ResultCode,
+    pub lease_id: Option<ReservationId>,
+    pub lease_epoch: Option<u64>,
+    pub deadline_slot: Option<Slot>,
     pub from_retry_cache: bool,
 }
 
@@ -105,13 +108,16 @@ impl From<SubmissionResult> for SubmissionCommitted {
     fn from(value: SubmissionResult) -> Self {
         Self {
             applied_lsn: value.applied_lsn,
-            outcome: value.outcome,
+            result_code: value.outcome.result_code,
+            lease_id: value.outcome.reservation_id,
+            lease_epoch: value.outcome.lease_epoch,
+            deadline_slot: value.outcome.deadline_slot,
             from_retry_cache: value.from_retry_cache,
         }
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SubmissionFailure {
     pub category: SubmissionErrorCategory,
     pub code: SubmissionFailureCode,
@@ -206,7 +212,7 @@ impl InvalidRequestReason {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResourceResponse {
     Found(ResourceView),
     NotFound,
@@ -218,10 +224,29 @@ pub enum ResourceResponse {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResourceViewState {
+    Available,
+    Reserved,
+    Active,
+    Revoking,
+}
+
+impl From<ResourceState> for ResourceViewState {
+    fn from(value: ResourceState) -> Self {
+        match value {
+            ResourceState::Available => Self::Available,
+            ResourceState::Reserved => Self::Reserved,
+            ResourceState::Confirmed => Self::Active,
+            ResourceState::Revoking => Self::Revoking,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ResourceView {
     pub resource_id: ResourceId,
-    pub state: ResourceState,
-    pub current_reservation_id: Option<ReservationId>,
+    pub state: ResourceViewState,
+    pub current_lease_id: Option<ReservationId>,
     pub version: u64,
 }
 
@@ -229,16 +254,39 @@ impl From<ResourceRecord> for ResourceView {
     fn from(value: ResourceRecord) -> Self {
         Self {
             resource_id: value.resource_id,
-            state: value.current_state,
-            current_reservation_id: value.current_reservation_id,
+            state: value.current_state.into(),
+            current_lease_id: value.current_reservation_id,
             version: value.version,
         }
     }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ReservationResponse {
-    Found(ReservationView),
+pub enum LeaseViewState {
+    Reserved,
+    Active,
+    Revoking,
+    Released,
+    Expired,
+    Revoked,
+}
+
+impl From<ReservationState> for LeaseViewState {
+    fn from(value: ReservationState) -> Self {
+        match value {
+            ReservationState::Reserved => Self::Reserved,
+            ReservationState::Confirmed => Self::Active,
+            ReservationState::Revoking => Self::Revoking,
+            ReservationState::Released => Self::Released,
+            ReservationState::Expired => Self::Expired,
+            ReservationState::Revoked => Self::Revoked,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LeaseResponse {
+    Found(LeaseView),
     NotFound,
     Retired,
     EngineHalted,
@@ -248,31 +296,32 @@ pub enum ReservationResponse {
     },
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ReservationView {
-    pub reservation_id: ReservationId,
-    pub resource_id: ResourceId,
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LeaseView {
+    pub lease_id: ReservationId,
     pub holder_id: HolderId,
+    pub state: LeaseViewState,
     pub lease_epoch: u64,
-    pub state: ReservationState,
     pub created_lsn: Lsn,
-    pub deadline_slot: Slot,
+    pub deadline_slot: Option<Slot>,
     pub released_lsn: Option<Lsn>,
     pub retire_after_slot: Option<Slot>,
+    pub member_resource_ids: Vec<ResourceId>,
 }
 
-impl From<ReservationRecord> for ReservationView {
-    fn from(value: ReservationRecord) -> Self {
+impl LeaseView {
+    #[must_use]
+    pub fn from_db(db: &AllocDb, value: ReservationRecord) -> Self {
         Self {
-            reservation_id: value.reservation_id,
-            resource_id: value.resource_id,
+            lease_id: value.reservation_id,
             holder_id: value.holder_id,
+            state: value.state.into(),
             lease_epoch: value.lease_epoch,
-            state: value.state,
             created_lsn: value.created_lsn,
-            deadline_slot: value.deadline_slot,
+            deadline_slot: Some(value.deadline_slot),
             released_lsn: value.released_lsn,
             retire_after_slot: value.retire_after_slot,
+            member_resource_ids: db.reservation_member_resource_ids(value),
         }
     }
 }
@@ -282,7 +331,7 @@ pub struct MetricsResponse {
     pub metrics: EngineMetrics,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum TickExpirationsResponse {
     Applied(TickExpirationsApplied),
     Rejected(SubmissionFailure),
@@ -314,8 +363,8 @@ impl SingleNodeEngine {
             ApiRequest::GetResource(request) => {
                 ApiResponse::GetResource(self.handle_resource_request(request))
             }
-            ApiRequest::GetReservation(request) => {
-                ApiResponse::GetReservation(self.handle_reservation_request(request))
+            ApiRequest::GetLease(request) => {
+                ApiResponse::GetLease(self.handle_lease_request(request))
             }
             ApiRequest::GetMetrics(request) => ApiResponse::GetMetrics(MetricsResponse {
                 metrics: self.metrics(request.current_wall_clock_slot),
@@ -367,14 +416,14 @@ impl SingleNodeEngine {
             })
     }
 
-    fn handle_reservation_request(&self, request: ReservationRequest) -> ReservationResponse {
+    fn handle_lease_request(&self, request: LeaseRequest) -> LeaseResponse {
         if let Some(error) = self.read_error(request.required_lsn) {
             return match error {
-                ReadError::EngineHalted => ReservationResponse::EngineHalted,
+                ReadError::EngineHalted => LeaseResponse::EngineHalted,
                 ReadError::RequiredLsnNotApplied {
                     required_lsn,
                     last_applied_lsn,
-                } => ReservationResponse::FenceNotApplied {
+                } => LeaseResponse::FenceNotApplied {
                     required_lsn,
                     last_applied_lsn,
                 },
@@ -383,11 +432,11 @@ impl SingleNodeEngine {
 
         match self
             .db()
-            .reservation(request.reservation_id, request.current_slot)
+            .reservation(request.lease_id, request.current_slot)
         {
-            Ok(record) => ReservationResponse::Found(record.into()),
-            Err(ReservationLookupError::NotFound) => ReservationResponse::NotFound,
-            Err(ReservationLookupError::Retired) => ReservationResponse::Retired,
+            Ok(record) => LeaseResponse::Found(LeaseView::from_db(self.db(), record)),
+            Err(ReservationLookupError::NotFound) => LeaseResponse::NotFound,
+            Err(ReservationLookupError::Retired) => LeaseResponse::Retired,
         }
     }
 

--- a/crates/allocdb-node/src/api_codec.rs
+++ b/crates/allocdb-node/src/api_codec.rs
@@ -1,15 +1,16 @@
 use allocdb_core::HealthMetrics;
+use allocdb_core::SlotOverflowKind;
 use allocdb_core::ids::{HolderId, Lsn, ReservationId, ResourceId, Slot};
-use allocdb_core::result::{CommandOutcome, ResultCode};
-use allocdb_core::{ReservationState, ResourceState, SlotOverflowKind};
+use allocdb_core::result::ResultCode;
 
 use crate::engine::{EngineMetrics, RecoveryStartupKind, RecoveryStatus, SubmissionErrorCategory};
 
 use super::{
-    ApiRequest, ApiResponse, InvalidRequestReason, MetricsRequest, MetricsResponse,
-    ReservationRequest, ReservationResponse, ReservationView, ResourceRequest, ResourceResponse,
-    ResourceView, SubmissionCommitted, SubmissionFailure, SubmissionFailureCode, SubmitRequest,
-    SubmitResponse, TickExpirationsApplied, TickExpirationsRequest, TickExpirationsResponse,
+    ApiRequest, ApiResponse, InvalidRequestReason, LeaseRequest, LeaseResponse, LeaseView,
+    LeaseViewState, MetricsRequest, MetricsResponse, ResourceRequest, ResourceResponse,
+    ResourceView, ResourceViewState, SubmissionCommitted, SubmissionFailure, SubmissionFailureCode,
+    SubmitRequest, SubmitResponse, TickExpirationsApplied, TickExpirationsRequest,
+    TickExpirationsResponse,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -41,11 +42,11 @@ pub fn encode_request(request: &ApiRequest) -> Result<Vec<u8>, ApiCodecError> {
             encode_optional_lsn(&mut bytes, request.required_lsn);
             bytes.extend_from_slice(&request.resource_id.get().to_le_bytes());
         }
-        ApiRequest::GetReservation(request) => {
+        ApiRequest::GetLease(request) => {
             bytes.push(3);
             encode_optional_lsn(&mut bytes, request.required_lsn);
             bytes.extend_from_slice(&request.current_slot.get().to_le_bytes());
-            bytes.extend_from_slice(&request.reservation_id.get().to_le_bytes());
+            bytes.extend_from_slice(&request.lease_id.get().to_le_bytes());
         }
         ApiRequest::GetMetrics(request) => {
             bytes.push(4);
@@ -75,10 +76,10 @@ pub fn decode_request(bytes: &[u8]) -> Result<ApiRequest, ApiCodecError> {
             required_lsn: cursor.read_optional_u64()?.map(Lsn),
             resource_id: ResourceId(cursor.read_u128()?),
         }),
-        3 => ApiRequest::GetReservation(ReservationRequest {
+        3 => ApiRequest::GetLease(LeaseRequest {
             required_lsn: cursor.read_optional_u64()?.map(Lsn),
             current_slot: Slot(cursor.read_u64()?),
-            reservation_id: ReservationId(cursor.read_u128()?),
+            lease_id: ReservationId(cursor.read_u128()?),
         }),
         4 => ApiRequest::GetMetrics(MetricsRequest {
             current_wall_clock_slot: Slot(cursor.read_u64()?),
@@ -102,7 +103,7 @@ pub fn encode_response(response: &ApiResponse) -> Vec<u8> {
         }
         ApiResponse::Submit(SubmitResponse::Rejected(response)) => {
             bytes.push(2);
-            encode_submission_failure(&mut bytes, *response);
+            encode_submission_failure(&mut bytes, response);
         }
         ApiResponse::GetResource(ResourceResponse::Found(response)) => {
             bytes.push(3);
@@ -118,17 +119,17 @@ pub fn encode_response(response: &ApiResponse) -> Vec<u8> {
             bytes.push(5);
             encode_read_fence(&mut bytes, *required_lsn, *last_applied_lsn);
         }
-        ApiResponse::GetReservation(ReservationResponse::Found(response)) => {
+        ApiResponse::GetLease(LeaseResponse::Found(response)) => {
             bytes.push(6);
-            encode_reservation_view(&mut bytes, *response);
+            encode_lease_view(&mut bytes, response);
         }
-        ApiResponse::GetReservation(ReservationResponse::NotFound) => {
+        ApiResponse::GetLease(LeaseResponse::NotFound) => {
             bytes.push(7);
         }
-        ApiResponse::GetReservation(ReservationResponse::Retired) => {
+        ApiResponse::GetLease(LeaseResponse::Retired) => {
             bytes.push(8);
         }
-        ApiResponse::GetReservation(ReservationResponse::FenceNotApplied {
+        ApiResponse::GetLease(LeaseResponse::FenceNotApplied {
             required_lsn,
             last_applied_lsn,
         }) => {
@@ -142,7 +143,7 @@ pub fn encode_response(response: &ApiResponse) -> Vec<u8> {
         ApiResponse::GetResource(ResourceResponse::EngineHalted) => {
             bytes.push(11);
         }
-        ApiResponse::GetReservation(ReservationResponse::EngineHalted) => {
+        ApiResponse::GetLease(LeaseResponse::EngineHalted) => {
             bytes.push(12);
         }
         ApiResponse::TickExpirations(TickExpirationsResponse::Applied(response)) => {
@@ -151,7 +152,7 @@ pub fn encode_response(response: &ApiResponse) -> Vec<u8> {
         }
         ApiResponse::TickExpirations(TickExpirationsResponse::Rejected(response)) => {
             bytes.push(14);
-            encode_submission_failure(&mut bytes, *response);
+            encode_submission_failure(&mut bytes, response);
         }
     }
     bytes
@@ -180,14 +181,12 @@ pub fn decode_response(bytes: &[u8]) -> Result<ApiResponse, ApiCodecError> {
                 last_applied_lsn,
             })
         }
-        6 => ApiResponse::GetReservation(ReservationResponse::Found(decode_reservation_view(
-            &mut cursor,
-        )?)),
-        7 => ApiResponse::GetReservation(ReservationResponse::NotFound),
-        8 => ApiResponse::GetReservation(ReservationResponse::Retired),
+        6 => ApiResponse::GetLease(LeaseResponse::Found(decode_lease_view(&mut cursor)?)),
+        7 => ApiResponse::GetLease(LeaseResponse::NotFound),
+        8 => ApiResponse::GetLease(LeaseResponse::Retired),
         9 => {
             let (required_lsn, last_applied_lsn) = decode_read_fence(&mut cursor)?;
-            ApiResponse::GetReservation(ReservationResponse::FenceNotApplied {
+            ApiResponse::GetLease(LeaseResponse::FenceNotApplied {
                 required_lsn,
                 last_applied_lsn,
             })
@@ -196,7 +195,7 @@ pub fn decode_response(bytes: &[u8]) -> Result<ApiResponse, ApiCodecError> {
             metrics: decode_metrics(&mut cursor)?,
         }),
         11 => ApiResponse::GetResource(ResourceResponse::EngineHalted),
-        12 => ApiResponse::GetReservation(ReservationResponse::EngineHalted),
+        12 => ApiResponse::GetLease(LeaseResponse::EngineHalted),
         13 => ApiResponse::TickExpirations(TickExpirationsResponse::Applied(
             decode_tick_expirations_applied(&mut cursor)?,
         )),
@@ -211,7 +210,10 @@ pub fn decode_response(bytes: &[u8]) -> Result<ApiResponse, ApiCodecError> {
 
 fn encode_submission_committed(bytes: &mut Vec<u8>, response: SubmissionCommitted) {
     bytes.extend_from_slice(&response.applied_lsn.get().to_le_bytes());
-    encode_command_outcome(bytes, response.outcome);
+    bytes.push(encode_result_code(response.result_code));
+    encode_optional_u128(bytes, response.lease_id.map(ReservationId::get));
+    encode_optional_u64(bytes, response.lease_epoch);
+    encode_optional_u64(bytes, response.deadline_slot.map(Slot::get));
     encode_bool(bytes, response.from_retry_cache);
 }
 
@@ -220,12 +222,15 @@ fn decode_submission_committed(
 ) -> Result<SubmissionCommitted, ApiCodecError> {
     Ok(SubmissionCommitted {
         applied_lsn: Lsn(cursor.read_u64()?),
-        outcome: decode_command_outcome(cursor)?,
+        result_code: decode_result_code(cursor.read_u8()?)?,
+        lease_id: cursor.read_optional_u128()?.map(ReservationId),
+        lease_epoch: cursor.read_optional_u64()?,
+        deadline_slot: cursor.read_optional_u64()?.map(Slot),
         from_retry_cache: cursor.read_bool()?,
     })
 }
 
-fn encode_submission_failure(bytes: &mut Vec<u8>, response: SubmissionFailure) {
+fn encode_submission_failure(bytes: &mut Vec<u8>, response: &SubmissionFailure) {
     bytes.push(encode_submission_error_category(response.category));
     match response.code {
         SubmissionFailureCode::EngineHalted => {
@@ -330,43 +335,43 @@ fn decode_invalid_request_reason(
 
 fn encode_resource_view(bytes: &mut Vec<u8>, view: ResourceView) {
     bytes.extend_from_slice(&view.resource_id.get().to_le_bytes());
-    bytes.push(encode_resource_state(view.state));
-    encode_optional_u128(bytes, view.current_reservation_id.map(ReservationId::get));
+    bytes.push(encode_resource_view_state(view.state));
+    encode_optional_u128(bytes, view.current_lease_id.map(ReservationId::get));
     bytes.extend_from_slice(&view.version.to_le_bytes());
 }
 
 fn decode_resource_view(cursor: &mut Cursor<'_>) -> Result<ResourceView, ApiCodecError> {
     Ok(ResourceView {
         resource_id: ResourceId(cursor.read_u128()?),
-        state: decode_resource_state(cursor.read_u8()?)?,
-        current_reservation_id: cursor.read_optional_u128()?.map(ReservationId),
+        state: decode_resource_view_state(cursor.read_u8()?)?,
+        current_lease_id: cursor.read_optional_u128()?.map(ReservationId),
         version: cursor.read_u64()?,
     })
 }
 
-fn encode_reservation_view(bytes: &mut Vec<u8>, view: ReservationView) {
-    bytes.extend_from_slice(&view.reservation_id.get().to_le_bytes());
-    bytes.extend_from_slice(&view.resource_id.get().to_le_bytes());
+fn encode_lease_view(bytes: &mut Vec<u8>, view: &LeaseView) {
+    bytes.extend_from_slice(&view.lease_id.get().to_le_bytes());
     bytes.extend_from_slice(&view.holder_id.get().to_le_bytes());
+    bytes.push(encode_lease_view_state(view.state));
     bytes.extend_from_slice(&view.lease_epoch.to_le_bytes());
-    bytes.push(encode_reservation_state(view.state));
     bytes.extend_from_slice(&view.created_lsn.get().to_le_bytes());
-    bytes.extend_from_slice(&view.deadline_slot.get().to_le_bytes());
+    encode_optional_u64(bytes, view.deadline_slot.map(Slot::get));
     encode_optional_u64(bytes, view.released_lsn.map(Lsn::get));
     encode_optional_u64(bytes, view.retire_after_slot.map(Slot::get));
+    encode_resource_ids(bytes, &view.member_resource_ids);
 }
 
-fn decode_reservation_view(cursor: &mut Cursor<'_>) -> Result<ReservationView, ApiCodecError> {
-    Ok(ReservationView {
-        reservation_id: ReservationId(cursor.read_u128()?),
-        resource_id: ResourceId(cursor.read_u128()?),
+fn decode_lease_view(cursor: &mut Cursor<'_>) -> Result<LeaseView, ApiCodecError> {
+    Ok(LeaseView {
+        lease_id: ReservationId(cursor.read_u128()?),
         holder_id: HolderId(cursor.read_u128()?),
+        state: decode_lease_view_state(cursor.read_u8()?)?,
         lease_epoch: cursor.read_u64()?,
-        state: decode_reservation_state(cursor.read_u8()?)?,
         created_lsn: Lsn(cursor.read_u64()?),
-        deadline_slot: Slot(cursor.read_u64()?),
+        deadline_slot: cursor.read_optional_u64()?.map(Slot),
         released_lsn: cursor.read_optional_u64()?.map(Lsn),
         retire_after_slot: cursor.read_optional_u64()?.map(Slot),
+        member_resource_ids: decode_resource_ids(cursor)?,
     })
 }
 
@@ -454,22 +459,6 @@ fn decode_health_metrics(cursor: &mut Cursor<'_>) -> Result<HealthMetrics, ApiCo
     })
 }
 
-fn encode_command_outcome(bytes: &mut Vec<u8>, outcome: CommandOutcome) {
-    bytes.push(encode_result_code(outcome.result_code));
-    encode_optional_u128(bytes, outcome.reservation_id.map(ReservationId::get));
-    encode_optional_u64(bytes, outcome.lease_epoch);
-    encode_optional_u64(bytes, outcome.deadline_slot.map(Slot::get));
-}
-
-fn decode_command_outcome(cursor: &mut Cursor<'_>) -> Result<CommandOutcome, ApiCodecError> {
-    Ok(CommandOutcome {
-        result_code: decode_result_code(cursor.read_u8()?)?,
-        reservation_id: cursor.read_optional_u128()?.map(ReservationId),
-        lease_epoch: cursor.read_optional_u64()?,
-        deadline_slot: cursor.read_optional_u64()?.map(Slot),
-    })
-}
-
 fn encode_optional_lsn(bytes: &mut Vec<u8>, value: Option<Lsn>) {
     encode_optional_u64(bytes, value.map(Lsn::get));
 }
@@ -505,6 +494,14 @@ fn encode_bytes(bytes: &mut Vec<u8>, payload: &[u8]) -> Result<(), ApiCodecError
     Ok(())
 }
 
+fn encode_resource_ids(bytes: &mut Vec<u8>, resource_ids: &[ResourceId]) {
+    let len = u32::try_from(resource_ids.len()).expect("resource id list length must fit u32");
+    bytes.extend_from_slice(&len.to_le_bytes());
+    for resource_id in resource_ids {
+        bytes.extend_from_slice(&resource_id.get().to_le_bytes());
+    }
+}
+
 fn encode_submission_error_category(category: SubmissionErrorCategory) -> u8 {
     match category {
         SubmissionErrorCategory::DefiniteFailure => 1,
@@ -523,21 +520,21 @@ fn decode_submission_error_category(value: u8) -> Result<SubmissionErrorCategory
     }
 }
 
-fn encode_resource_state(state: ResourceState) -> u8 {
+fn encode_resource_view_state(state: ResourceViewState) -> u8 {
     match state {
-        ResourceState::Available => 1,
-        ResourceState::Reserved => 2,
-        ResourceState::Confirmed => 3,
-        ResourceState::Revoking => 4,
+        ResourceViewState::Available => 1,
+        ResourceViewState::Reserved => 2,
+        ResourceViewState::Active => 3,
+        ResourceViewState::Revoking => 4,
     }
 }
 
-fn decode_resource_state(value: u8) -> Result<ResourceState, ApiCodecError> {
+fn decode_resource_view_state(value: u8) -> Result<ResourceViewState, ApiCodecError> {
     match value {
-        1 => Ok(ResourceState::Available),
-        2 => Ok(ResourceState::Reserved),
-        3 => Ok(ResourceState::Confirmed),
-        4 => Ok(ResourceState::Revoking),
+        1 => Ok(ResourceViewState::Available),
+        2 => Ok(ResourceViewState::Reserved),
+        3 => Ok(ResourceViewState::Active),
+        4 => Ok(ResourceViewState::Revoking),
         value => Err(ApiCodecError::InvalidEnumValue {
             kind: "resource_state",
             value,
@@ -545,27 +542,27 @@ fn decode_resource_state(value: u8) -> Result<ResourceState, ApiCodecError> {
     }
 }
 
-fn encode_reservation_state(state: ReservationState) -> u8 {
+fn encode_lease_view_state(state: LeaseViewState) -> u8 {
     match state {
-        ReservationState::Reserved => 1,
-        ReservationState::Confirmed => 2,
-        ReservationState::Released => 3,
-        ReservationState::Expired => 4,
-        ReservationState::Revoking => 5,
-        ReservationState::Revoked => 6,
+        LeaseViewState::Reserved => 1,
+        LeaseViewState::Active => 2,
+        LeaseViewState::Released => 3,
+        LeaseViewState::Expired => 4,
+        LeaseViewState::Revoking => 5,
+        LeaseViewState::Revoked => 6,
     }
 }
 
-fn decode_reservation_state(value: u8) -> Result<ReservationState, ApiCodecError> {
+fn decode_lease_view_state(value: u8) -> Result<LeaseViewState, ApiCodecError> {
     match value {
-        1 => Ok(ReservationState::Reserved),
-        2 => Ok(ReservationState::Confirmed),
-        3 => Ok(ReservationState::Released),
-        4 => Ok(ReservationState::Expired),
-        5 => Ok(ReservationState::Revoking),
-        6 => Ok(ReservationState::Revoked),
+        1 => Ok(LeaseViewState::Reserved),
+        2 => Ok(LeaseViewState::Active),
+        3 => Ok(LeaseViewState::Released),
+        4 => Ok(LeaseViewState::Expired),
+        5 => Ok(LeaseViewState::Revoking),
+        6 => Ok(LeaseViewState::Revoked),
         value => Err(ApiCodecError::InvalidEnumValue {
-            kind: "reservation_state",
+            kind: "lease_state",
             value,
         }),
     }
@@ -753,4 +750,17 @@ impl<'a> Cursor<'a> {
         self.offset += len;
         Ok(slice.to_vec())
     }
+
+    fn read_resource_ids(&mut self) -> Result<Vec<ResourceId>, ApiCodecError> {
+        let len = usize::try_from(self.read_u32()?).map_err(|_| ApiCodecError::LengthTooLarge)?;
+        let mut resource_ids = Vec::with_capacity(len);
+        for _ in 0..len {
+            resource_ids.push(ResourceId(self.read_u128()?));
+        }
+        Ok(resource_ids)
+    }
+}
+
+fn decode_resource_ids(cursor: &mut Cursor<'_>) -> Result<Vec<ResourceId>, ApiCodecError> {
+    cursor.read_resource_ids()
 }

--- a/crates/allocdb-node/src/api_tests.rs
+++ b/crates/allocdb-node/src/api_tests.rs
@@ -2,18 +2,18 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use allocdb_core::SlotOverflowKind;
 use allocdb_core::command::{ClientRequest, Command};
 use allocdb_core::config::Config;
 use allocdb_core::ids::{ClientId, HolderId, Lsn, OperationId, ReservationId, ResourceId, Slot};
 use allocdb_core::result::ResultCode;
-use allocdb_core::{ReservationState, ResourceState, SlotOverflowKind};
 
 use super::{
-    ApiCodecError, ApiRequest, ApiResponse, InvalidRequestReason, MetricsRequest, MetricsResponse,
-    ReservationRequest, ReservationResponse, ResourceRequest, ResourceResponse,
-    SubmissionFailureCode, SubmitRequest, SubmitResponse, TickExpirationsApplied,
-    TickExpirationsRequest, TickExpirationsResponse, decode_request, decode_response,
-    encode_request, encode_response,
+    ApiCodecError, ApiRequest, ApiResponse, InvalidRequestReason, LeaseRequest, LeaseResponse,
+    LeaseViewState, MetricsRequest, MetricsResponse, ResourceRequest, ResourceResponse,
+    ResourceViewState, SubmissionFailureCode, SubmitRequest, SubmitResponse,
+    TickExpirationsApplied, TickExpirationsRequest, TickExpirationsResponse, decode_request,
+    decode_response, encode_request, encode_response,
 };
 use crate::engine::{
     CrashPlan, CrashPoint, EngineConfig, PersistFailurePhase, RecoveryStartupKind,
@@ -50,6 +50,13 @@ fn core_config() -> Config {
     }
 }
 
+fn bundle_core_config() -> Config {
+    Config {
+        max_bundle_size: 4,
+        ..core_config()
+    }
+}
+
 fn engine_config() -> EngineConfig {
     EngineConfig {
         max_submission_queue: 2,
@@ -74,6 +81,22 @@ fn reserve_request(resource_id: u128, operation_id: u128, holder_id: u128) -> Cl
         client_id: ClientId(7),
         command: Command::Reserve {
             resource_id: ResourceId(resource_id),
+            holder_id: HolderId(holder_id),
+            ttl_slots: 3,
+        },
+    }
+}
+
+fn reserve_bundle_request(
+    resource_ids: &[u128],
+    operation_id: u128,
+    holder_id: u128,
+) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::ReserveBundle {
+            resource_ids: resource_ids.iter().copied().map(ResourceId).collect(),
             holder_id: HolderId(holder_id),
             ttl_slots: 3,
         },
@@ -115,8 +138,8 @@ fn request_codec_round_trips_all_variants() {
             resource_id: ResourceId(12),
             required_lsn: Some(Lsn(7)),
         }),
-        ApiRequest::GetReservation(ReservationRequest {
-            reservation_id: ReservationId(13),
+        ApiRequest::GetLease(LeaseRequest {
+            lease_id: ReservationId(13),
             current_slot: Slot(14),
             required_lsn: None,
         }),
@@ -138,12 +161,18 @@ fn submit_response_cases() -> Vec<ApiResponse> {
     vec![
         ApiResponse::Submit(SubmitResponse::Committed(super::SubmissionCommitted {
             applied_lsn: Lsn(1),
-            outcome: allocdb_core::result::CommandOutcome::new(ResultCode::Ok),
+            result_code: ResultCode::Ok,
+            lease_id: None,
+            lease_epoch: None,
+            deadline_slot: None,
             from_retry_cache: false,
         })),
         ApiResponse::Submit(SubmitResponse::Committed(super::SubmissionCommitted {
             applied_lsn: Lsn(2),
-            outcome: allocdb_core::result::CommandOutcome::new(ResultCode::SlotOverflow),
+            result_code: ResultCode::SlotOverflow,
+            lease_id: None,
+            lease_epoch: None,
+            deadline_slot: None,
             from_retry_cache: true,
         })),
         ApiResponse::Submit(SubmitResponse::Rejected(super::SubmissionFailure {
@@ -171,14 +200,14 @@ fn read_response_cases() -> Vec<ApiResponse> {
     vec![
         ApiResponse::GetResource(ResourceResponse::Found(super::ResourceView {
             resource_id: ResourceId(21),
-            state: ResourceState::Confirmed,
-            current_reservation_id: Some(ReservationId(22)),
+            state: ResourceViewState::Active,
+            current_lease_id: Some(ReservationId(22)),
             version: 5,
         })),
         ApiResponse::GetResource(ResourceResponse::Found(super::ResourceView {
             resource_id: ResourceId(23),
-            state: ResourceState::Revoking,
-            current_reservation_id: Some(ReservationId(24)),
+            state: ResourceViewState::Revoking,
+            current_lease_id: Some(ReservationId(24)),
             version: 6,
         })),
         ApiResponse::GetResource(ResourceResponse::NotFound),
@@ -187,43 +216,43 @@ fn read_response_cases() -> Vec<ApiResponse> {
             required_lsn: Lsn(9),
             last_applied_lsn: Some(Lsn(8)),
         }),
-        ApiResponse::GetReservation(ReservationResponse::Found(super::ReservationView {
-            reservation_id: ReservationId(31),
-            resource_id: ResourceId(32),
+        ApiResponse::GetLease(LeaseResponse::Found(super::LeaseView {
+            lease_id: ReservationId(31),
             holder_id: HolderId(33),
             lease_epoch: 2,
-            state: ReservationState::Released,
+            state: LeaseViewState::Released,
             created_lsn: Lsn(2),
-            deadline_slot: Slot(7),
+            deadline_slot: Some(Slot(7)),
             released_lsn: Some(Lsn(3)),
             retire_after_slot: Some(Slot(9)),
+            member_resource_ids: vec![ResourceId(32)],
         })),
-        ApiResponse::GetReservation(ReservationResponse::Found(super::ReservationView {
-            reservation_id: ReservationId(34),
-            resource_id: ResourceId(35),
+        ApiResponse::GetLease(LeaseResponse::Found(super::LeaseView {
+            lease_id: ReservationId(34),
             holder_id: HolderId(36),
             lease_epoch: 4,
-            state: ReservationState::Revoking,
+            state: LeaseViewState::Revoking,
             created_lsn: Lsn(5),
-            deadline_slot: Slot(11),
+            deadline_slot: Some(Slot(11)),
             released_lsn: None,
             retire_after_slot: None,
+            member_resource_ids: vec![ResourceId(35)],
         })),
-        ApiResponse::GetReservation(ReservationResponse::Found(super::ReservationView {
-            reservation_id: ReservationId(37),
-            resource_id: ResourceId(38),
+        ApiResponse::GetLease(LeaseResponse::Found(super::LeaseView {
+            lease_id: ReservationId(37),
             holder_id: HolderId(39),
             lease_epoch: 4,
-            state: ReservationState::Revoked,
+            state: LeaseViewState::Revoked,
             created_lsn: Lsn(6),
-            deadline_slot: Slot(12),
+            deadline_slot: Some(Slot(12)),
             released_lsn: Some(Lsn(8)),
             retire_after_slot: Some(Slot(14)),
+            member_resource_ids: vec![ResourceId(38)],
         })),
-        ApiResponse::GetReservation(ReservationResponse::NotFound),
-        ApiResponse::GetReservation(ReservationResponse::Retired),
-        ApiResponse::GetReservation(ReservationResponse::EngineHalted),
-        ApiResponse::GetReservation(ReservationResponse::FenceNotApplied {
+        ApiResponse::GetLease(LeaseResponse::NotFound),
+        ApiResponse::GetLease(LeaseResponse::Retired),
+        ApiResponse::GetLease(LeaseResponse::EngineHalted),
+        ApiResponse::GetLease(LeaseResponse::FenceNotApplied {
             required_lsn: Lsn(11),
             last_applied_lsn: None,
         }),
@@ -329,7 +358,10 @@ fn api_submit_commits_and_exposes_retry_cache() {
         first,
         ApiResponse::Submit(SubmitResponse::Committed(super::SubmissionCommitted {
             applied_lsn: Lsn(1),
-            outcome: allocdb_core::result::CommandOutcome::new(ResultCode::Ok),
+            result_code: ResultCode::Ok,
+            lease_id: None,
+            lease_epoch: None,
+            deadline_slot: None,
             from_retry_cache: false,
         }))
     );
@@ -337,7 +369,10 @@ fn api_submit_commits_and_exposes_retry_cache() {
         second,
         ApiResponse::Submit(SubmitResponse::Committed(super::SubmissionCommitted {
             applied_lsn: Lsn(1),
-            outcome: allocdb_core::result::CommandOutcome::new(ResultCode::Ok),
+            result_code: ResultCode::Ok,
+            lease_id: None,
+            lease_epoch: None,
+            deadline_slot: None,
             from_retry_cache: true,
         }))
     );
@@ -369,7 +404,10 @@ fn api_reserve_retry_preserves_lease_epoch_outcome() {
         first,
         ApiResponse::Submit(SubmitResponse::Committed(super::SubmissionCommitted {
             applied_lsn: Lsn(2),
-            outcome: expected,
+            result_code: expected.result_code,
+            lease_id: expected.reservation_id,
+            lease_epoch: expected.lease_epoch,
+            deadline_slot: expected.deadline_slot,
             from_retry_cache: false,
         }))
     );
@@ -377,7 +415,10 @@ fn api_reserve_retry_preserves_lease_epoch_outcome() {
         second,
         ApiResponse::Submit(SubmitResponse::Committed(super::SubmissionCommitted {
             applied_lsn: Lsn(2),
-            outcome: expected,
+            result_code: expected.result_code,
+            lease_id: expected.reservation_id,
+            lease_epoch: expected.lease_epoch,
+            deadline_slot: expected.deadline_slot,
             from_retry_cache: true,
         }))
     );
@@ -450,29 +491,29 @@ fn api_reads_enforce_fence_and_return_views() {
         resource,
         ApiResponse::GetResource(ResourceResponse::Found(super::ResourceView {
             resource_id: ResourceId(11),
-            state: ResourceState::Reserved,
-            current_reservation_id: Some(ReservationId(2)),
+            state: ResourceViewState::Reserved,
+            current_lease_id: Some(ReservationId(2)),
             version: 1,
         }))
     );
 
-    let reservation = engine.handle_api_request(ApiRequest::GetReservation(ReservationRequest {
-        reservation_id: ReservationId(2),
+    let reservation = engine.handle_api_request(ApiRequest::GetLease(LeaseRequest {
+        lease_id: ReservationId(2),
         current_slot: Slot(2),
         required_lsn: Some(Lsn(2)),
     }));
     assert_eq!(
         reservation,
-        ApiResponse::GetReservation(ReservationResponse::Found(super::ReservationView {
-            reservation_id: ReservationId(2),
-            resource_id: ResourceId(11),
+        ApiResponse::GetLease(LeaseResponse::Found(super::LeaseView {
+            lease_id: ReservationId(2),
             holder_id: HolderId(9),
             lease_epoch: 1,
-            state: ReservationState::Reserved,
+            state: LeaseViewState::Reserved,
             created_lsn: Lsn(2),
-            deadline_slot: Slot(5),
+            deadline_slot: Some(Slot(5)),
             released_lsn: None,
             retire_after_slot: None,
+            member_resource_ids: vec![ResourceId(11)],
         }))
     );
 
@@ -498,16 +539,13 @@ fn api_reservation_reports_retired_history() {
         release_request(2, 3, 9),
     )));
 
-    let response = engine.handle_api_request(ApiRequest::GetReservation(ReservationRequest {
-        reservation_id: ReservationId(2),
+    let response = engine.handle_api_request(ApiRequest::GetLease(LeaseRequest {
+        lease_id: ReservationId(2),
         current_slot: Slot(8),
         required_lsn: Some(Lsn(3)),
     }));
 
-    assert_eq!(
-        response,
-        ApiResponse::GetReservation(ReservationResponse::Retired)
-    );
+    assert_eq!(response, ApiResponse::GetLease(LeaseResponse::Retired));
 
     let later_write = engine.handle_api_request(ApiRequest::Submit(
         SubmitRequest::from_client_request(Slot(8), create_request(12, 4)),
@@ -517,16 +555,15 @@ fn api_reservation_reports_retired_history() {
         ApiResponse::Submit(SubmitResponse::Committed(_))
     ));
 
-    let after_later_write =
-        engine.handle_api_request(ApiRequest::GetReservation(ReservationRequest {
-            reservation_id: ReservationId(2),
-            current_slot: Slot(8),
-            required_lsn: Some(Lsn(4)),
-        }));
+    let after_later_write = engine.handle_api_request(ApiRequest::GetLease(LeaseRequest {
+        lease_id: ReservationId(2),
+        current_slot: Slot(8),
+        required_lsn: Some(Lsn(4)),
+    }));
 
     assert_eq!(
         after_later_write,
-        ApiResponse::GetReservation(ReservationResponse::Retired)
+        ApiResponse::GetLease(LeaseResponse::Retired)
     );
 
     drop(engine);
@@ -566,29 +603,29 @@ fn api_tick_expirations_commits_due_internal_expire() {
         resource,
         ApiResponse::GetResource(ResourceResponse::Found(super::ResourceView {
             resource_id: ResourceId(11),
-            state: ResourceState::Available,
-            current_reservation_id: None,
+            state: ResourceViewState::Available,
+            current_lease_id: None,
             version: 2,
         }))
     );
 
-    let reservation = engine.handle_api_request(ApiRequest::GetReservation(ReservationRequest {
-        reservation_id: ReservationId(2),
+    let reservation = engine.handle_api_request(ApiRequest::GetLease(LeaseRequest {
+        lease_id: ReservationId(2),
         current_slot: Slot(20),
         required_lsn: Some(Lsn(3)),
     }));
     assert_eq!(
         reservation,
-        ApiResponse::GetReservation(ReservationResponse::Found(super::ReservationView {
-            reservation_id: ReservationId(2),
-            resource_id: ResourceId(11),
+        ApiResponse::GetLease(LeaseResponse::Found(super::LeaseView {
+            lease_id: ReservationId(2),
             holder_id: HolderId(9),
             lease_epoch: 2,
-            state: ReservationState::Expired,
+            state: LeaseViewState::Expired,
             created_lsn: Lsn(2),
-            deadline_slot: Slot(5),
+            deadline_slot: Some(Slot(5)),
             released_lsn: Some(Lsn(3)),
             retire_after_slot: Some(Slot(24)),
+            member_resource_ids: vec![ResourceId(11)],
         }))
     );
 
@@ -622,12 +659,12 @@ fn api_reads_reject_when_engine_is_halted() {
         ApiResponse::GetResource(ResourceResponse::EngineHalted)
     );
     assert_eq!(
-        live.handle_api_request(ApiRequest::GetReservation(ReservationRequest {
-            reservation_id: ReservationId(11),
+        live.handle_api_request(ApiRequest::GetLease(LeaseRequest {
+            lease_id: ReservationId(11),
             current_slot: Slot(1),
             required_lsn: None,
         })),
-        ApiResponse::GetReservation(ReservationResponse::EngineHalted)
+        ApiResponse::GetLease(LeaseResponse::EngineHalted)
     );
     drop(live);
 
@@ -641,8 +678,8 @@ fn api_reads_reject_when_engine_is_halted() {
         })),
         ApiResponse::GetResource(ResourceResponse::Found(super::ResourceView {
             resource_id: ResourceId(11),
-            state: ResourceState::Available,
-            current_reservation_id: None,
+            state: ResourceViewState::Available,
+            current_lease_id: None,
             version: 0,
         }))
     );
@@ -735,7 +772,10 @@ fn api_bytes_recovery_preserves_state_and_retry_cache() {
         first,
         ApiResponse::Submit(SubmitResponse::Committed(super::SubmissionCommitted {
             applied_lsn: Lsn(1),
-            outcome: allocdb_core::result::CommandOutcome::new(ResultCode::Ok),
+            result_code: ResultCode::Ok,
+            lease_id: None,
+            lease_epoch: None,
+            deadline_slot: None,
             from_retry_cache: false,
         }))
     );
@@ -751,7 +791,10 @@ fn api_bytes_recovery_preserves_state_and_retry_cache() {
         retry,
         ApiResponse::Submit(SubmitResponse::Committed(super::SubmissionCommitted {
             applied_lsn: Lsn(1),
-            outcome: allocdb_core::result::CommandOutcome::new(ResultCode::Ok),
+            result_code: ResultCode::Ok,
+            lease_id: None,
+            lease_epoch: None,
+            deadline_slot: None,
             from_retry_cache: true,
         }))
     );
@@ -766,11 +809,117 @@ fn api_bytes_recovery_preserves_state_and_retry_cache() {
         read,
         ApiResponse::GetResource(ResourceResponse::Found(super::ResourceView {
             resource_id: ResourceId(11),
-            state: ResourceState::Available,
-            current_reservation_id: None,
+            state: ResourceViewState::Available,
+            current_lease_id: None,
             version: 0,
         }))
     );
+
+    drop(recovered);
+    let _ = fs::remove_file(&snapshot_path);
+    fs::remove_file(&wal_path).unwrap();
+}
+
+#[test]
+fn api_get_lease_exposes_bundle_members_in_stable_order() {
+    let wal_path = test_path("bundle-lease-view");
+    let mut engine =
+        SingleNodeEngine::open(bundle_core_config(), engine_config(), &wal_path).unwrap();
+
+    let _ = engine.handle_api_request(ApiRequest::Submit(SubmitRequest::from_client_request(
+        Slot(1),
+        create_request(11, 1),
+    )));
+    let _ = engine.handle_api_request(ApiRequest::Submit(SubmitRequest::from_client_request(
+        Slot(2),
+        create_request(12, 2),
+    )));
+    let reserve = engine.handle_api_request(ApiRequest::Submit(
+        SubmitRequest::from_client_request(Slot(3), reserve_bundle_request(&[11, 12], 3, 9)),
+    ));
+    assert_eq!(
+        reserve,
+        ApiResponse::Submit(SubmitResponse::Committed(super::SubmissionCommitted {
+            applied_lsn: Lsn(3),
+            result_code: ResultCode::Ok,
+            lease_id: Some(ReservationId(3)),
+            lease_epoch: Some(1),
+            deadline_slot: Some(Slot(6)),
+            from_retry_cache: false,
+        }))
+    );
+
+    let lease = engine.handle_api_request(ApiRequest::GetLease(LeaseRequest {
+        lease_id: ReservationId(3),
+        current_slot: Slot(3),
+        required_lsn: Some(Lsn(3)),
+    }));
+    assert_eq!(
+        lease,
+        ApiResponse::GetLease(LeaseResponse::Found(super::LeaseView {
+            lease_id: ReservationId(3),
+            holder_id: HolderId(9),
+            state: LeaseViewState::Reserved,
+            lease_epoch: 1,
+            created_lsn: Lsn(3),
+            deadline_slot: Some(Slot(6)),
+            released_lsn: None,
+            retire_after_slot: None,
+            member_resource_ids: vec![ResourceId(11), ResourceId(12)],
+        }))
+    );
+
+    drop(engine);
+    fs::remove_file(&wal_path).unwrap();
+}
+
+#[test]
+fn api_bytes_recovery_preserves_bundle_lease_view_shape() {
+    let wal_path = test_path("bundle-lease-recovery");
+    let snapshot_path = test_snapshot_path("bundle-lease-recovery");
+    let mut engine =
+        SingleNodeEngine::open(bundle_core_config(), engine_config(), &wal_path).unwrap();
+
+    let create_first = encode_request(&ApiRequest::Submit(SubmitRequest::from_client_request(
+        Slot(1),
+        create_request(11, 1),
+    )))
+    .unwrap();
+    let create_second = encode_request(&ApiRequest::Submit(SubmitRequest::from_client_request(
+        Slot(2),
+        create_request(12, 2),
+    )))
+    .unwrap();
+    let reserve_bundle = encode_request(&ApiRequest::Submit(SubmitRequest::from_client_request(
+        Slot(3),
+        reserve_bundle_request(&[11, 12], 3, 9),
+    )))
+    .unwrap();
+    let lease_read = encode_request(&ApiRequest::GetLease(LeaseRequest {
+        lease_id: ReservationId(3),
+        current_slot: Slot(3),
+        required_lsn: Some(Lsn(3)),
+    }))
+    .unwrap();
+
+    let _ = engine.handle_api_bytes(&create_first).unwrap();
+    let _ = engine.handle_api_bytes(&create_second).unwrap();
+    let _ = engine.handle_api_bytes(&reserve_bundle).unwrap();
+    let live_read = decode_response(&engine.handle_api_bytes(&lease_read).unwrap()).unwrap();
+
+    drop(engine);
+
+    let mut recovered = SingleNodeEngine::recover(
+        bundle_core_config(),
+        engine_config(),
+        &snapshot_path,
+        &wal_path,
+    )
+    .unwrap();
+    let recovered_read =
+        decode_response(&recovered.handle_api_bytes(&lease_read).unwrap()).unwrap();
+
+    assert_eq!(recovered_read, live_read);
 
     drop(recovered);
     let _ = fs::remove_file(&snapshot_path);

--- a/crates/allocdb-node/src/bin/allocdb-jepsen/events.rs
+++ b/crates/allocdb-node/src/bin/allocdb-jepsen/events.rs
@@ -1,4 +1,3 @@
-use allocdb_core::ReservationState;
 use allocdb_core::command::{ClientRequest, Command as AllocCommand};
 use allocdb_core::ids::{HolderId, Lsn, OperationId, ReservationId, ResourceId, Slot};
 use allocdb_core::result::ResultCode;
@@ -9,9 +8,9 @@ use allocdb_node::jepsen::{
 };
 use allocdb_node::local_cluster::LocalClusterReplicaConfig;
 use allocdb_node::{
-    ApiRequest, ApiResponse, ReservationRequest, ReservationResponse, ResourceRequest,
-    ResourceResponse, SubmissionFailure, SubmissionFailureCode, SubmitRequest, SubmitResponse,
-    TickExpirationsRequest, TickExpirationsResponse, decode_response,
+    ApiRequest, ApiResponse, LeaseRequest, LeaseResponse, LeaseViewState, ResourceRequest,
+    ResourceResponse, ResourceViewState, SubmissionFailure, SubmissionFailureCode, SubmitRequest,
+    SubmitResponse, TickExpirationsRequest, TickExpirationsResponse, decode_response,
 };
 
 use crate::ExternalTestbed;
@@ -30,7 +29,7 @@ pub(super) enum RemoteApiOutcome {
 pub(super) enum ResourceReadObservation {
     Available,
     Held {
-        state: allocdb_core::ResourceState,
+        state: ResourceViewState,
         current_reservation_id: Option<ReservationId>,
         version: u64,
     },
@@ -76,7 +75,7 @@ pub(super) fn create_qemu_resource<T: ExternalTestbed>(
     ));
     match send_replica_api_request(layout, primary, &request)? {
         RemoteApiOutcome::Api(ApiResponse::Submit(SubmitResponse::Committed(response)))
-            if response.outcome.result_code == ResultCode::Ok =>
+            if response.result_code == ResultCode::Ok =>
         {
             Ok(())
         }
@@ -183,7 +182,7 @@ pub(super) fn tick_expirations_event<T: ExternalTestbed>(
                 ))
             }
             TickExpirationsResponse::Rejected(failure) => {
-                Ok((operation, outcome_from_submission_failure(failure), None))
+                Ok((operation, outcome_from_submission_failure(&failure), None))
             }
         },
         RemoteApiOutcome::Api(other) => Err(format!(
@@ -219,44 +218,40 @@ pub(super) fn reservation_read_event<T: ExternalTestbed>(
         request_slot: Some(current_slot),
         ttl_slots: None,
     };
-    let request = ApiRequest::GetReservation(ReservationRequest {
-        reservation_id,
+    let request = ApiRequest::GetLease(LeaseRequest {
+        lease_id: reservation_id,
         current_slot,
         required_lsn,
     });
     match send_replica_api_request(layout, replica, &request)? {
-        RemoteApiOutcome::Api(ApiResponse::GetReservation(ReservationResponse::Found(
-            reservation,
-        ))) => Ok((
+        RemoteApiOutcome::Api(ApiResponse::GetLease(LeaseResponse::Found(reservation))) => Ok((
             operation,
             JepsenEventOutcome::SuccessfulRead(JepsenSuccessfulRead {
                 target: JepsenReadTarget::Reservation,
                 served_by: replica.replica_id,
                 served_role: replica.role,
                 observed_lsn: required_lsn,
-                state: JepsenReadState::Reservation(map_reservation_state(reservation)),
+                state: JepsenReadState::Reservation(map_reservation_state(&reservation)),
             }),
         )),
-        RemoteApiOutcome::Api(ApiResponse::GetReservation(ReservationResponse::NotFound)) => Ok((
+        RemoteApiOutcome::Api(ApiResponse::GetLease(LeaseResponse::NotFound)) => Ok((
             operation,
             JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::NotFound),
         )),
-        RemoteApiOutcome::Api(ApiResponse::GetReservation(ReservationResponse::Retired)) => Ok((
+        RemoteApiOutcome::Api(ApiResponse::GetLease(LeaseResponse::Retired)) => Ok((
             operation,
             JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::Retired),
         )),
-        RemoteApiOutcome::Api(ApiResponse::GetReservation(
-            ReservationResponse::FenceNotApplied { .. },
-        )) => Ok((
-            operation,
-            JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::FenceNotApplied),
-        )),
-        RemoteApiOutcome::Api(ApiResponse::GetReservation(ReservationResponse::EngineHalted)) => {
+        RemoteApiOutcome::Api(ApiResponse::GetLease(LeaseResponse::FenceNotApplied { .. })) => {
             Ok((
                 operation,
-                JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::EngineHalted),
+                JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::FenceNotApplied),
             ))
         }
+        RemoteApiOutcome::Api(ApiResponse::GetLease(LeaseResponse::EngineHalted)) => Ok((
+            operation,
+            JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::EngineHalted),
+        )),
         RemoteApiOutcome::Api(other) => Err(format!(
             "reservation read for {} returned unexpected response {other:?}",
             reservation_id.get()
@@ -304,12 +299,12 @@ pub(super) fn classify_resource_read_outcome(
                     resource.resource_id.get()
                 ));
             }
-            if matches!(resource.state, allocdb_core::ResourceState::Available) {
+            if matches!(resource.state, ResourceViewState::Available) {
                 Ok(ResourceReadObservation::Available)
             } else {
                 Ok(ResourceReadObservation::Held {
                     state: resource.state,
-                    current_reservation_id: resource.current_reservation_id,
+                    current_reservation_id: resource.current_lease_id,
                     version: resource.version,
                 })
             }
@@ -338,26 +333,28 @@ pub(super) fn classify_resource_read_outcome(
 }
 
 pub(super) fn map_reservation_state(
-    reservation: allocdb_node::ReservationView,
+    reservation: &allocdb_node::LeaseView,
 ) -> JepsenReservationState {
     match reservation.state {
-        ReservationState::Reserved => JepsenReservationState::Active {
-            resource_id: reservation.resource_id,
+        LeaseViewState::Reserved => JepsenReservationState::Active {
+            resource_id: reservation.member_resource_ids[0],
             holder_id: reservation.holder_id.get(),
-            expires_at_slot: reservation.deadline_slot,
+            expires_at_slot: reservation
+                .deadline_slot
+                .expect("live lease should expose deadline"),
             confirmed: false,
         },
-        ReservationState::Confirmed | ReservationState::Revoking => {
-            JepsenReservationState::Active {
-                resource_id: reservation.resource_id,
-                holder_id: reservation.holder_id.get(),
-                expires_at_slot: reservation.deadline_slot,
-                confirmed: true,
-            }
-        }
-        ReservationState::Released | ReservationState::Expired | ReservationState::Revoked => {
+        LeaseViewState::Active | LeaseViewState::Revoking => JepsenReservationState::Active {
+            resource_id: reservation.member_resource_ids[0],
+            holder_id: reservation.holder_id.get(),
+            expires_at_slot: reservation
+                .deadline_slot
+                .expect("live lease should expose deadline"),
+            confirmed: true,
+        },
+        LeaseViewState::Released | LeaseViewState::Expired | LeaseViewState::Revoked => {
             JepsenReservationState::Released {
-                resource_id: reservation.resource_id,
+                resource_id: reservation.member_resource_ids[0],
                 holder_id: reservation.holder_id.get(),
                 released_lsn: reservation.released_lsn,
             }
@@ -365,7 +362,7 @@ pub(super) fn map_reservation_state(
     }
 }
 
-pub(super) fn outcome_from_submission_failure(failure: SubmissionFailure) -> JepsenEventOutcome {
+pub(super) fn outcome_from_submission_failure(failure: &SubmissionFailure) -> JepsenEventOutcome {
     if failure.category == allocdb_node::SubmissionErrorCategory::Indefinite {
         return JepsenEventOutcome::Ambiguous(JepsenAmbiguousOutcome::IndefiniteWrite);
     }
@@ -410,14 +407,12 @@ fn map_reserve_submit_response(
     response: SubmitResponse,
 ) -> Result<(JepsenOperation, JepsenEventOutcome, Option<ReserveCommit>), String> {
     match response {
-        SubmitResponse::Committed(response) => match response.outcome.result_code {
+        SubmitResponse::Committed(response) => match response.result_code {
             ResultCode::Ok => {
                 let reservation_id = response
-                    .outcome
-                    .reservation_id
+                    .lease_id
                     .ok_or_else(|| String::from("reserve commit missing reservation_id"))?;
                 let expires_at_slot = response
-                    .outcome
                     .deadline_slot
                     .ok_or_else(|| String::from("reserve commit missing deadline_slot"))?;
                 Ok((
@@ -460,7 +455,7 @@ fn map_reserve_submit_response(
             other => Err(format!("unexpected reserve result code {other:?}")),
         },
         SubmitResponse::Rejected(failure) => {
-            Ok((operation, outcome_from_submission_failure(failure), None))
+            Ok((operation, outcome_from_submission_failure(&failure), None))
         }
     }
 }
@@ -815,16 +810,16 @@ mod tests {
 
     #[test]
     fn revoking_reservation_maps_to_confirmed_active_state() {
-        let state = map_reservation_state(allocdb_node::ReservationView {
-            reservation_id: ReservationId(11),
-            resource_id: ResourceId(22),
+        let state = map_reservation_state(&allocdb_node::LeaseView {
+            lease_id: ReservationId(11),
             holder_id: HolderId(33),
             lease_epoch: 2,
-            state: ReservationState::Revoking,
+            state: LeaseViewState::Revoking,
             created_lsn: Lsn(1),
-            deadline_slot: Slot(9),
+            deadline_slot: Some(Slot(9)),
             released_lsn: None,
             retire_after_slot: None,
+            member_resource_ids: vec![ResourceId(22)],
         });
         assert_eq!(
             state,
@@ -839,16 +834,16 @@ mod tests {
 
     #[test]
     fn revoked_reservation_maps_to_released_state() {
-        let state = map_reservation_state(allocdb_node::ReservationView {
-            reservation_id: ReservationId(11),
-            resource_id: ResourceId(22),
+        let state = map_reservation_state(&allocdb_node::LeaseView {
+            lease_id: ReservationId(11),
             holder_id: HolderId(33),
             lease_epoch: 2,
-            state: ReservationState::Revoked,
+            state: LeaseViewState::Revoked,
             created_lsn: Lsn(1),
-            deadline_slot: Slot(9),
+            deadline_slot: Some(Slot(9)),
             released_lsn: Some(Lsn(4)),
             retire_after_slot: Some(Slot(17)),
+            member_resource_ids: vec![ResourceId(22)],
         });
         assert_eq!(
             state,
@@ -862,7 +857,7 @@ mod tests {
 
     #[test]
     fn outcome_from_submission_failure_maps_rejection_codes() {
-        let overloaded = outcome_from_submission_failure(SubmissionFailure {
+        let overloaded = outcome_from_submission_failure(&SubmissionFailure {
             category: SubmissionErrorCategory::DefiniteFailure,
             code: SubmissionFailureCode::Overloaded {
                 queue_depth: 9,
@@ -874,7 +869,7 @@ mod tests {
             JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::Busy)
         );
 
-        let invalid = outcome_from_submission_failure(SubmissionFailure {
+        let invalid = outcome_from_submission_failure(&SubmissionFailure {
             category: SubmissionErrorCategory::DefiniteFailure,
             code: SubmissionFailureCode::InvalidRequest(InvalidRequestReason::InvalidLayout),
         });
@@ -883,7 +878,7 @@ mod tests {
             JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::InvalidRequest)
         );
 
-        let halted = outcome_from_submission_failure(SubmissionFailure {
+        let halted = outcome_from_submission_failure(&SubmissionFailure {
             category: SubmissionErrorCategory::DefiniteFailure,
             code: SubmissionFailureCode::EngineHalted,
         });
@@ -900,8 +895,8 @@ mod tests {
             responses.push(Ok(encoded_api_response(&ApiResponse::GetResource(
                 ResourceResponse::Found(allocdb_node::ResourceView {
                     resource_id: ResourceId(7),
-                    state: allocdb_core::ResourceState::Reserved,
-                    current_reservation_id: Some(ReservationId(70 + u128::from(attempt))),
+                    state: ResourceViewState::Reserved,
+                    current_lease_id: Some(ReservationId(70 + u128::from(attempt))),
                     version: attempt,
                 }),
             ))));
@@ -918,8 +913,8 @@ mod tests {
         responses.push(Ok(encoded_api_response(&ApiResponse::GetResource(
             ResourceResponse::Found(allocdb_node::ResourceView {
                 resource_id: ResourceId(7),
-                state: allocdb_core::ResourceState::Reserved,
-                current_reservation_id: Some(ReservationId(999)),
+                state: ResourceViewState::Reserved,
+                current_lease_id: Some(ReservationId(999)),
                 version: 99,
             }),
         ))));
@@ -966,8 +961,8 @@ mod tests {
             Ok(encoded_api_response(&ApiResponse::GetResource(
                 ResourceResponse::Found(allocdb_node::ResourceView {
                     resource_id: ResourceId(7),
-                    state: allocdb_core::ResourceState::Reserved,
-                    current_reservation_id: Some(ReservationId(70)),
+                    state: ResourceViewState::Reserved,
+                    current_lease_id: Some(ReservationId(70)),
                     version: 1,
                 }),
             ))),
@@ -983,8 +978,8 @@ mod tests {
             Ok(encoded_api_response(&ApiResponse::GetResource(
                 ResourceResponse::Found(allocdb_node::ResourceView {
                     resource_id: ResourceId(7),
-                    state: allocdb_core::ResourceState::Available,
-                    current_reservation_id: None,
+                    state: ResourceViewState::Available,
+                    current_lease_id: None,
                     version: 2,
                 }),
             ))),
@@ -1039,8 +1034,8 @@ mod tests {
             RemoteApiOutcome::Api(ApiResponse::GetResource(ResourceResponse::Found(
                 allocdb_node::ResourceView {
                     resource_id: ResourceId(8),
-                    state: allocdb_core::ResourceState::Available,
-                    current_reservation_id: None,
+                    state: ResourceViewState::Available,
+                    current_lease_id: None,
                     version: 1,
                 },
             ))),

--- a/crates/allocdb-node/src/bin/allocdb-jepsen/tests.rs
+++ b/crates/allocdb-node/src/bin/allocdb-jepsen/tests.rs
@@ -21,7 +21,6 @@ use crate::watch_render::{
     compact_counter, compact_fault_window_progress, parse_watch_event_line, progress_bar,
 };
 use allocdb_core::{
-    ReservationState, ResourceState,
     ids::{HolderId, Lsn, ReservationId, ResourceId, Slot},
     result::ResultCode,
 };
@@ -35,8 +34,8 @@ use allocdb_node::local_cluster::{
     LocalClusterReplicaConfig, ReplicaRuntimeState, ReplicaRuntimeStatus,
 };
 use allocdb_node::{
-    ApiResponse, ReplicaId, ReplicaPaths, ReplicaRole, ResourceResponse, SubmissionFailure,
-    SubmissionFailureCode, SubmitResponse,
+    ApiResponse, LeaseViewState, ReplicaId, ReplicaPaths, ReplicaRole, ResourceResponse,
+    ResourceViewState, SubmissionFailure, SubmissionFailureCode, SubmitResponse,
 };
 use std::fs;
 use std::path::PathBuf;
@@ -121,7 +120,7 @@ fn release_gate_plan_includes_faulted_qemu_runs() {
 
 #[test]
 fn indefinite_submission_failure_maps_to_ambiguous_outcome() {
-    let outcome = outcome_from_submission_failure(SubmissionFailure {
+    let outcome = outcome_from_submission_failure(&SubmissionFailure {
         category: allocdb_node::SubmissionErrorCategory::Indefinite,
         code: SubmissionFailureCode::StorageFailure,
     });
@@ -133,16 +132,16 @@ fn indefinite_submission_failure_maps_to_ambiguous_outcome() {
 
 #[test]
 fn expired_reservation_maps_to_released_read_state() {
-    let state = map_reservation_state(allocdb_node::ReservationView {
-        reservation_id: ReservationId(11),
-        resource_id: ResourceId(22),
+    let state = map_reservation_state(&allocdb_node::LeaseView {
+        lease_id: ReservationId(11),
         holder_id: HolderId(33),
         lease_epoch: 2,
-        state: ReservationState::Expired,
+        state: LeaseViewState::Expired,
         created_lsn: Lsn(1),
-        deadline_slot: Slot(9),
+        deadline_slot: Some(Slot(9)),
         released_lsn: Some(Lsn(4)),
         retire_after_slot: Some(Slot(17)),
+        member_resource_ids: vec![ResourceId(22)],
     });
     assert_eq!(
         state,
@@ -220,8 +219,8 @@ fn probe_submit_and_read_validation_cover_pass_and_fail_paths() {
 
     let ok_read = ApiResponse::GetResource(ResourceResponse::Found(allocdb_node::ResourceView {
         resource_id: ResourceId(41),
-        state: ResourceState::Available,
-        current_reservation_id: None,
+        state: ResourceViewState::Available,
+        current_lease_id: None,
         version: 1,
     }));
     assert!(validate_probe_read_response("qemu", 41, &ok_read).is_ok());
@@ -242,8 +241,8 @@ fn classify_resource_read_outcome_distinguishes_available_and_held_states() {
         RemoteApiOutcome::Api(ApiResponse::GetResource(ResourceResponse::Found(
             allocdb_node::ResourceView {
                 resource_id: ResourceId(41),
-                state: ResourceState::Available,
-                current_reservation_id: None,
+                state: ResourceViewState::Available,
+                current_lease_id: None,
                 version: 2,
             },
         ))),
@@ -256,8 +255,8 @@ fn classify_resource_read_outcome_distinguishes_available_and_held_states() {
         RemoteApiOutcome::Api(ApiResponse::GetResource(ResourceResponse::Found(
             allocdb_node::ResourceView {
                 resource_id: ResourceId(41),
-                state: ResourceState::Reserved,
-                current_reservation_id: Some(ReservationId(7)),
+                state: ResourceViewState::Reserved,
+                current_lease_id: Some(ReservationId(7)),
                 version: 3,
             },
         ))),
@@ -266,7 +265,7 @@ fn classify_resource_read_outcome_distinguishes_available_and_held_states() {
     assert_eq!(
         held,
         ResourceReadObservation::Held {
-            state: ResourceState::Reserved,
+            state: ResourceViewState::Reserved,
             current_reservation_id: Some(ReservationId(7)),
             version: 3,
         }
@@ -290,8 +289,8 @@ fn classify_resource_read_outcome_rejects_mismatched_resource() {
         RemoteApiOutcome::Api(ApiResponse::GetResource(ResourceResponse::Found(
             allocdb_node::ResourceView {
                 resource_id: ResourceId(12),
-                state: ResourceState::Available,
-                current_reservation_id: None,
+                state: ResourceViewState::Available,
+                current_lease_id: None,
                 version: 0,
             },
         ))),

--- a/crates/allocdb-node/src/bin/allocdb-local-cluster.rs
+++ b/crates/allocdb-node/src/bin/allocdb-local-cluster.rs
@@ -21,9 +21,9 @@ use allocdb_node::replica::{
     ReplicaId, ReplicaIdentity, ReplicaNode, ReplicaNodeStatus, ReplicaPreparedKind, ReplicaRole,
 };
 use allocdb_node::{
-    ApiRequest, ApiResponse, MetricsResponse, ReservationResponse, ResourceResponse,
-    SubmissionFailure, SubmissionFailureCode, SubmitResponse, TickExpirationsApplied,
-    TickExpirationsResponse, decode_request, encode_response,
+    ApiRequest, ApiResponse, LeaseResponse, MetricsResponse, ResourceResponse, SubmissionFailure,
+    SubmissionFailureCode, SubmitResponse, TickExpirationsApplied, TickExpirationsResponse,
+    decode_request, encode_response,
 };
 use log::{info, warn};
 
@@ -747,7 +747,7 @@ fn handle_client_stream(
     let response = match request {
         ApiRequest::Submit(request) => handle_replicated_submit(node, layout, replica, &request),
         ApiRequest::GetResource(request) => Ok(handle_resource_request(node, request)),
-        ApiRequest::GetReservation(request) => Ok(handle_reservation_request(node, request)),
+        ApiRequest::GetLease(request) => Ok(handle_lease_request(node, request)),
         ApiRequest::GetMetrics(request) => Ok(handle_metrics_request(node, request)),
         ApiRequest::TickExpirations(request) => {
             handle_replicated_tick_expirations(node, layout, replica, request)
@@ -1444,39 +1444,41 @@ fn handle_resource_request(node: &ReplicaNode, request: allocdb_node::ResourceRe
     encode_response(&ApiResponse::GetResource(response))
 }
 
-fn handle_reservation_request(
-    node: &ReplicaNode,
-    request: allocdb_node::ReservationRequest,
-) -> Vec<u8> {
+fn handle_lease_request(node: &ReplicaNode, request: allocdb_node::LeaseRequest) -> Vec<u8> {
     let response = match node.enforce_primary_read(request.required_lsn.unwrap_or(Lsn(0))) {
         Ok(()) => match node
             .engine()
             .expect("primary read requires one live engine")
             .db()
-            .reservation(request.reservation_id, request.current_slot)
+            .reservation(request.lease_id, request.current_slot)
         {
-            Ok(record) => ReservationResponse::Found(record.into()),
-            Err(ReservationLookupError::NotFound) => ReservationResponse::NotFound,
-            Err(ReservationLookupError::Retired) => ReservationResponse::Retired,
+            Ok(record) => LeaseResponse::Found(allocdb_node::LeaseView::from_db(
+                node.engine()
+                    .expect("primary read requires one live engine")
+                    .db(),
+                record,
+            )),
+            Err(ReservationLookupError::NotFound) => LeaseResponse::NotFound,
+            Err(ReservationLookupError::Retired) => LeaseResponse::Retired,
         },
         Err(allocdb_node::NotPrimaryReadError::Fence(
             allocdb_node::ReadError::RequiredLsnNotApplied {
                 required_lsn,
                 last_applied_lsn,
             },
-        )) => ReservationResponse::FenceNotApplied {
+        )) => LeaseResponse::FenceNotApplied {
             required_lsn,
             last_applied_lsn,
         },
         Err(
             allocdb_node::NotPrimaryReadError::Fence(allocdb_node::ReadError::EngineHalted)
             | allocdb_node::NotPrimaryReadError::ReplicaCrashed,
-        ) => ReservationResponse::EngineHalted,
+        ) => LeaseResponse::EngineHalted,
         Err(allocdb_node::NotPrimaryReadError::Role(role)) => {
             return encode_control_error_bytes(&format!("not primary: role={}", encode_role(role)));
         }
     };
-    encode_response(&ApiResponse::GetReservation(response))
+    encode_response(&ApiResponse::GetLease(response))
 }
 
 fn handle_metrics_request(node: &ReplicaNode, request: allocdb_node::MetricsRequest) -> Vec<u8> {

--- a/crates/allocdb-node/src/lib.rs
+++ b/crates/allocdb-node/src/lib.rs
@@ -12,11 +12,11 @@ pub(crate) mod replicated_simulation;
 pub(crate) mod simulation;
 
 pub use api::{
-    ApiCodecError, ApiRequest, ApiResponse, InvalidRequestReason, MetricsRequest, MetricsResponse,
-    ReservationRequest, ReservationResponse, ReservationView, ResourceRequest, ResourceResponse,
-    ResourceView, SubmissionCommitted, SubmissionFailure, SubmissionFailureCode, SubmitRequest,
-    SubmitResponse, TickExpirationsApplied, TickExpirationsRequest, TickExpirationsResponse,
-    decode_request, decode_response, encode_request, encode_response,
+    ApiCodecError, ApiRequest, ApiResponse, InvalidRequestReason, LeaseRequest, LeaseResponse,
+    LeaseView, LeaseViewState, MetricsRequest, MetricsResponse, ResourceRequest, ResourceResponse,
+    ResourceView, ResourceViewState, SubmissionCommitted, SubmissionFailure, SubmissionFailureCode,
+    SubmitRequest, SubmitResponse, TickExpirationsApplied, TickExpirationsRequest,
+    TickExpirationsResponse, decode_request, decode_response, encode_request, encode_response,
 };
 pub use engine::{
     EngineConfig, EngineConfigError, EngineMetrics, EngineOpenError, EnqueueResult, ReadError,

--- a/crates/allocdb-node/tests/local_cluster_runner.rs
+++ b/crates/allocdb-node/tests/local_cluster_runner.rs
@@ -8,16 +8,16 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use allocdb_core::command::{ClientRequest, Command as AllocCommand};
 use allocdb_core::ids::{ClientId, HolderId, Lsn, OperationId, ResourceId, Slot};
-use allocdb_core::{ReservationState, ResourceState};
 use allocdb_node::local_cluster::{
     LocalClusterFaultState, LocalClusterLayout, LocalClusterTimelineEventKind,
     load_local_cluster_timeline, request_control_status,
 };
 use allocdb_node::{
-    ApiRequest, ApiResponse, ReplicaId, ReplicaMetadataFile, ReplicaRole, ResourceRequest,
-    ResourceResponse, SubmitRequest, SubmitResponse, TickExpirationsRequest,
-    TickExpirationsResponse, decode_response, encode_request,
+    ApiRequest, ApiResponse, LeaseRequest, LeaseResponse, ReplicaId, ReplicaMetadataFile,
+    ReplicaRole, ResourceRequest, ResourceResponse, SubmitRequest, SubmitResponse,
+    TickExpirationsRequest, TickExpirationsResponse, decode_response, encode_request,
 };
+use allocdb_node::{LeaseViewState, ResourceViewState};
 
 fn temp_workspace(name: &str) -> PathBuf {
     let nanos = SystemTime::now()
@@ -571,8 +571,7 @@ fn local_cluster_tick_expirations_replicates_internal_commands() {
         ApiResponse::Submit(SubmitResponse::Committed(response)) => {
             assert_eq!(response.applied_lsn, Lsn(2));
             response
-                .outcome
-                .reservation_id
+                .lease_id
                 .expect("reserve should assign one reservation id")
         }
         other => panic!("expected committed reserve response, got {other:?}"),
@@ -609,23 +608,23 @@ fn local_cluster_tick_expirations_replicates_internal_commands() {
     );
     match resource {
         ApiResponse::GetResource(ResourceResponse::Found(resource)) => {
-            assert_eq!(resource.state, ResourceState::Available);
-            assert_eq!(resource.current_reservation_id, None);
+            assert_eq!(resource.state, ResourceViewState::Available);
+            assert_eq!(resource.current_lease_id, None);
         }
         other => panic!("expected available resource after tick, got {other:?}"),
     }
 
     let reservation = send_api_request(
         primary.client_addr,
-        &ApiRequest::GetReservation(allocdb_node::ReservationRequest {
-            reservation_id,
+        &ApiRequest::GetLease(LeaseRequest {
+            lease_id: reservation_id,
             current_slot: Slot(12),
             required_lsn: Some(tick_lsn),
         }),
     );
     match reservation {
-        ApiResponse::GetReservation(allocdb_node::ReservationResponse::Found(reservation)) => {
-            assert_eq!(reservation.state, ReservationState::Expired);
+        ApiResponse::GetLease(LeaseResponse::Found(reservation)) => {
+            assert_eq!(reservation.state, LeaseViewState::Expired);
             assert_eq!(reservation.released_lsn, Some(tick_lsn));
         }
         other => panic!("expected expired reservation after tick, got {other:?}"),
@@ -667,8 +666,7 @@ fn local_cluster_tick_retry_drains_pending_internal_suffix_after_quorum_recovers
     );
     let reservation_id = match reserve {
         ApiResponse::Submit(SubmitResponse::Committed(response)) => response
-            .outcome
-            .reservation_id
+            .lease_id
             .expect("reserve should assign one reservation id"),
         other => panic!("expected committed reserve response, got {other:?}"),
     };
@@ -729,23 +727,23 @@ fn local_cluster_tick_retry_drains_pending_internal_suffix_after_quorum_recovers
     );
     match resource {
         ApiResponse::GetResource(ResourceResponse::Found(resource)) => {
-            assert_eq!(resource.state, ResourceState::Available);
-            assert_eq!(resource.current_reservation_id, None);
+            assert_eq!(resource.state, ResourceViewState::Available);
+            assert_eq!(resource.current_lease_id, None);
         }
         other => panic!("expected available resource after retry tick, got {other:?}"),
     }
 
     let reservation = send_api_request(
         primary.client_addr,
-        &ApiRequest::GetReservation(allocdb_node::ReservationRequest {
-            reservation_id,
+        &ApiRequest::GetLease(LeaseRequest {
+            lease_id: reservation_id,
             current_slot: Slot(12),
             required_lsn: Some(committed_lsn),
         }),
     );
     match reservation {
-        ApiResponse::GetReservation(allocdb_node::ReservationResponse::Found(reservation)) => {
-            assert_eq!(reservation.state, ReservationState::Expired);
+        ApiResponse::GetLease(LeaseResponse::Found(reservation)) => {
+            assert_eq!(reservation.state, LeaseViewState::Expired);
             assert_eq!(reservation.released_lsn, Some(committed_lsn));
         }
         other => panic!("expected expired reservation after retry tick, got {other:?}"),

--- a/docs/status.md
+++ b/docs/status.md
@@ -206,15 +206,15 @@
 - PR `#90` merged `M9-T07` on `main`: lease epochs now flow through holder-authorized commands and
   command outcomes, the core rejects stale holder epochs deterministically, and read/retry
   surfaces expose the current authority token for active reservations
-- issue `#85` / `M9-T08` is the active implementation slice on the current branch: the trusted
-  core now has explicit `revoke` / `reclaim` commands, `revoking` and `revoked` states, minimum
-  command/snapshot/API codec support for those states, and deterministic duplicate/recovery
-  handling on the branch
-- targeted validation on the active `#85` branch currently includes
-  `cargo test -p allocdb-core -- --nocapture`,
-  `cargo test -p allocdb-node api -- --nocapture`, and
-  `cargo test -p allocdb-node replicated_simulation -- --nocapture`
-- the active `#85` branch still keeps the `T08` / `T09` boundary explicit: it adds only the
-  revoke/reclaim persistence and replay support needed for the current path, while broader WAL,
-  transport, and replicated-surface cleanup stays deferred to `M9-T09` and `M9-T10`
-- the next planned code-bearing slices after `#85` remain `M9-T09` persistence and transport extension, `M9-T10` replication preservation, and `M9-T11` broader regression coverage
+- PR `#92` merged `M9-T08` on `main`: the trusted core now has explicit `revoke` / `reclaim`
+  commands, `revoking` and `revoked` states, and deterministic duplicate/recovery handling
+- issue `#86` / `M9-T09` is the active implementation slice on the current branch: the node API
+  and wire codec now expose the approved lease-centric surface with `get_lease`, flattened
+  committed results, `current_lease_id`, and ordered `member_resource_ids`, while keeping the
+  trusted-core naming and apply path intact
+- targeted validation on the active `#86` branch currently includes
+  `cargo test -p allocdb-node api -- --nocapture`
+- the active `#86` branch keeps the `T09` / `T10` boundary explicit: it finishes the lease
+  transport/read/recovery surface without adding new replication or view-change behavior
+- the next planned code-bearing slices after `#86` remain `M9-T10` replication preservation and
+  `M9-T11` broader regression coverage


### PR DESCRIPTION
## Summary
- switch the node API and wire codec to the approved lease-centric surface
- expose flattened committed fields, current_lease_id, and ordered member_resource_ids
- keep live and recovered lease reads aligned through new bundle/recovery regression coverage

## Validation
- cargo test -p allocdb-node api -- --nocapture
- ./scripts/preflight.sh

Closes #86