### PR TITLE
test: broaden lease regression coverage

### DIFF
--- a/crates/allocdb-node/src/replicated_simulation_tests.rs
+++ b/crates/allocdb-node/src/replicated_simulation_tests.rs
@@ -1420,6 +1420,106 @@ fn primary_crash_after_reply_preserves_read_and_retry_on_new_primary() {
 }
 
 #[test]
+fn primary_crash_after_quorum_bundle_retry_hits_reconstructed_retry_cache() {
+    let mut harness = bundle_primary_harness("replicated-bundle-after-quorum", 0x5a45_0001);
+
+    let create_first = harness
+        .client_submit(
+            replica(1),
+            Slot(1),
+            &create_payload(91, 901),
+            "bundle-after-quorum-create-first",
+        )
+        .unwrap();
+    commit_to_all_backups(
+        &mut harness,
+        "bundle-after-quorum-create-first",
+        create_first.lsn,
+    );
+
+    let create_second = harness
+        .client_submit(
+            replica(1),
+            Slot(2),
+            &create_payload(92, 902),
+            "bundle-after-quorum-create-second",
+        )
+        .unwrap();
+    commit_to_all_backups(
+        &mut harness,
+        "bundle-after-quorum-create-second",
+        create_second.lsn,
+    );
+
+    let payload = reserve_bundle_payload(&[91, 92], 31, 903);
+    let entry = harness
+        .client_submit(replica(1), Slot(3), &payload, "bundle-after-quorum")
+        .unwrap();
+    harness
+        .deliver_protocol_message("bundle-after-quorum-prepare-3-to-2")
+        .unwrap();
+    harness
+        .deliver_protocol_message("bundle-after-quorum-prepare-3-to-2-ack")
+        .unwrap();
+    assert_eq!(replica_commit_lsn(&harness, 1), Some(entry.lsn));
+    assert_eq!(replica_last_applied_lsn(&harness, 1), Some(entry.lsn));
+    assert_eq!(replica_commit_lsn(&harness, 2), Some(create_second.lsn));
+    assert_eq!(replica_prepared_len(&harness, 2), 1);
+
+    harness.crash_replica(replica(1)).unwrap();
+    harness.complete_view_change(replica(2), 2).unwrap();
+
+    let retry = harness
+        .client_submit_or_retry(replica(2), Slot(4), &payload, "bundle-after-quorum-retry")
+        .unwrap();
+    match retry {
+        ReplicatedClientRequestOutcome::Published(result) => {
+            assert_eq!(result.applied_lsn, entry.lsn);
+            assert_eq!(result.outcome.result_code, ResultCode::Ok);
+            assert_eq!(result.outcome.reservation_id, Some(ReservationId(3)));
+            assert_eq!(result.outcome.deadline_slot, Some(Slot(7)));
+            assert!(result.from_retry_cache);
+        }
+        other @ ReplicatedClientRequestOutcome::Prepared(_) => {
+            panic!("expected bundle retry cache hit after majority-committed crash, got {other:?}")
+        }
+    }
+
+    let first_member = harness
+        .read_resource(replica(2), ResourceId(91), Some(entry.lsn))
+        .unwrap()
+        .expect("new primary should preserve first committed bundle member");
+    assert_eq!(
+        first_member.current_state,
+        allocdb_core::ResourceState::Reserved
+    );
+    assert_eq!(first_member.current_reservation_id, Some(ReservationId(3)));
+
+    let second_member = harness
+        .read_resource(replica(2), ResourceId(92), Some(entry.lsn))
+        .unwrap()
+        .expect("new primary should preserve second committed bundle member");
+    assert_eq!(
+        second_member.current_state,
+        allocdb_core::ResourceState::Reserved
+    );
+    assert_eq!(second_member.current_reservation_id, Some(ReservationId(3)));
+    assert_eq!(
+        replica_reservation_member_ids(&harness, 2, 3, 4),
+        vec![ResourceId(91), ResourceId(92)]
+    );
+
+    let method = harness.rejoin_replica(replica(3), replica(2)).unwrap();
+    assert_eq!(method, ReplicaRejoinMethod::SuffixOnly);
+    assert_eq!(replica_last_applied_lsn(&harness, 2), Some(entry.lsn));
+    assert_eq!(replica_last_applied_lsn(&harness, 3), Some(entry.lsn));
+    assert_eq!(
+        replica_reservation_member_ids(&harness, 3, 3, 4),
+        vec![ResourceId(91), ResourceId(92)]
+    );
+}
+
+#[test]
 fn committed_bundle_membership_survives_failover_and_suffix_rejoin() {
     let mut harness = bundle_primary_harness("replicated-bundle-failover", 0x5a46_0001);
 

--- a/crates/allocdb-node/src/simulation_tests.rs
+++ b/crates/allocdb-node/src/simulation_tests.rs
@@ -1,6 +1,6 @@
 use allocdb_core::command::{ClientRequest, Command};
 use allocdb_core::config::Config;
-use allocdb_core::ids::{ClientId, HolderId, OperationId, ResourceId, Slot};
+use allocdb_core::ids::{ClientId, HolderId, OperationId, ReservationId, ResourceId, Slot};
 use allocdb_core::recovery::RecoveryError;
 use allocdb_core::result::ResultCode;
 use allocdb_core::wal::{DecodeError, ScanStopReason};
@@ -27,6 +27,13 @@ fn core_config() -> Config {
         max_client_retry_window_slots: 8,
         reservation_history_window_slots: 4,
         max_expiration_bucket_len: 8,
+    }
+}
+
+fn bundle_core_config() -> Config {
+    Config {
+        max_bundle_size: 4,
+        ..core_config()
     }
 }
 
@@ -61,6 +68,77 @@ fn reserve(
             resource_id: ResourceId(resource_id),
             holder_id: HolderId(holder_id),
             ttl_slots,
+        },
+    }
+}
+
+fn reserve_bundle(
+    resource_ids: &[u128],
+    holder_id: u128,
+    operation_id: u128,
+    ttl_slots: u64,
+) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::ReserveBundle {
+            resource_ids: resource_ids.iter().copied().map(ResourceId).collect(),
+            holder_id: HolderId(holder_id),
+            ttl_slots,
+        },
+    }
+}
+
+fn confirm(
+    reservation_id: u128,
+    holder_id: u128,
+    lease_epoch: u64,
+    operation_id: u128,
+) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::Confirm {
+            reservation_id: ReservationId(reservation_id),
+            holder_id: HolderId(holder_id),
+            lease_epoch,
+        },
+    }
+}
+
+fn release(
+    reservation_id: u128,
+    holder_id: u128,
+    lease_epoch: u64,
+    operation_id: u128,
+) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::Release {
+            reservation_id: ReservationId(reservation_id),
+            holder_id: HolderId(holder_id),
+            lease_epoch,
+        },
+    }
+}
+
+fn revoke(reservation_id: u128, operation_id: u128) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::Revoke {
+            reservation_id: ReservationId(reservation_id),
+        },
+    }
+}
+
+fn reclaim(reservation_id: u128, operation_id: u128) -> ClientRequest {
+    ClientRequest {
+        operation_id: OperationId(operation_id),
+        client_id: ClientId(7),
+        command: Command::Reclaim {
+            reservation_id: ReservationId(reservation_id),
         },
     }
 }
@@ -552,6 +630,74 @@ fn seeded_schedule_explores_retry_timing_reproducibly() {
 }
 
 #[test]
+fn simulated_sync_failure_recovers_bundle_retry_without_partial_membership() {
+    let mut harness = SimulationHarness::new(
+        "bundle-sync-failure-recovery",
+        0x188,
+        bundle_core_config(),
+        engine_config(),
+    )
+    .unwrap();
+
+    harness.advance_to(Slot(1));
+    harness.submit(create(11, 1)).unwrap();
+    harness.submit(create(12, 2)).unwrap();
+
+    harness.advance_to(Slot(2));
+    harness.inject_storage_fault(StorageFault::SyncFailure);
+    let error = harness
+        .submit(reserve_bundle(&[11, 12], 9, 3, 4))
+        .unwrap_err();
+
+    assert!(matches!(error, SubmissionError::WalFile(_)));
+    assert!(!harness.metrics().accepting_writes);
+
+    let recovered = harness.restart().unwrap();
+    assert_eq!(
+        recovered.recovery.startup_kind,
+        RecoveryStartupKind::WalOnly
+    );
+    assert_eq!(recovered.recovery.replayed_wal_frame_count, 3);
+    assert_eq!(
+        recovered
+            .recovery
+            .replayed_wal_last_lsn
+            .map(allocdb_core::Lsn::get),
+        Some(3)
+    );
+
+    for resource_id in [11, 12] {
+        let resource = harness
+            .engine()
+            .db()
+            .resource(ResourceId(resource_id))
+            .unwrap();
+        assert_eq!(resource.current_state, ResourceState::Reserved);
+        assert_eq!(resource.current_reservation_id, Some(ReservationId(3)));
+    }
+
+    let reservation = harness
+        .engine()
+        .db()
+        .reservation(ReservationId(3), harness.current_slot())
+        .unwrap();
+    assert_eq!(
+        harness
+            .engine()
+            .db()
+            .reservation_member_resource_ids(reservation),
+        vec![ResourceId(11), ResourceId(12)]
+    );
+
+    harness.advance_to(Slot(3));
+    let retry = harness.submit(reserve_bundle(&[11, 12], 9, 3, 4)).unwrap();
+    assert!(retry.from_retry_cache);
+    assert_eq!(retry.applied_lsn.get(), 3);
+    assert_eq!(retry.outcome.result_code, ResultCode::Ok);
+    assert_eq!(retry.outcome.reservation_id, Some(ReservationId(3)));
+}
+
+#[test]
 #[should_panic(expected = "schedule actions must have unique labels")]
 fn schedule_exploration_rejects_duplicate_labels() {
     let actions = [
@@ -706,6 +852,102 @@ fn simulated_slot_driver_handles_expiration_restart_path() {
             .state,
         ReservationState::Expired
     );
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn revoke_restart_preserves_epoch_barrier_until_explicit_reclaim() {
+    let mut harness = SimulationHarness::new(
+        "revoke-restart-epoch-barrier",
+        0x189,
+        bundle_core_config(),
+        engine_config(),
+    )
+    .unwrap();
+
+    harness.advance_to(Slot(1));
+    harness.submit(create(11, 1)).unwrap();
+    harness.submit(create(12, 2)).unwrap();
+
+    harness.advance_to(Slot(2));
+    let reserved = harness.submit(reserve_bundle(&[11, 12], 21, 3, 4)).unwrap();
+    assert_eq!(reserved.outcome.reservation_id, Some(ReservationId(3)));
+
+    harness.advance_to(Slot(3));
+    let confirmed = harness.submit(confirm(3, 21, 1, 4)).unwrap();
+    assert_eq!(confirmed.outcome.result_code, ResultCode::Ok);
+    let checkpoint = harness.checkpoint().unwrap();
+    assert_eq!(checkpoint.snapshot_lsn.map(allocdb_core::Lsn::get), Some(4));
+
+    harness.advance_to(Slot(4));
+    let revoked = harness.submit(revoke(3, 5)).unwrap();
+    assert_eq!(revoked.outcome.result_code, ResultCode::Ok);
+
+    let recovered = harness.restart().unwrap();
+    assert_eq!(
+        recovered.recovery.startup_kind,
+        RecoveryStartupKind::SnapshotAndWal
+    );
+    assert_eq!(
+        recovered
+            .recovery
+            .loaded_snapshot_lsn
+            .map(allocdb_core::Lsn::get),
+        Some(4)
+    );
+    assert_eq!(recovered.recovery.replayed_wal_frame_count, 1);
+    assert_eq!(
+        recovered
+            .recovery
+            .replayed_wal_last_lsn
+            .map(allocdb_core::Lsn::get),
+        Some(5)
+    );
+
+    for resource_id in [11, 12] {
+        let resource = harness
+            .engine()
+            .db()
+            .resource(ResourceId(resource_id))
+            .unwrap();
+        assert_eq!(resource.current_state, ResourceState::Revoking);
+        assert_eq!(resource.current_reservation_id, Some(ReservationId(3)));
+    }
+    assert_eq!(
+        harness
+            .engine()
+            .db()
+            .reservation(ReservationId(3), harness.current_slot())
+            .unwrap()
+            .state,
+        ReservationState::Revoking
+    );
+
+    harness.advance_to(Slot(5));
+    let stale_release = harness.submit(release(3, 21, 1, 6)).unwrap();
+    assert_eq!(stale_release.outcome.result_code, ResultCode::StaleEpoch);
+
+    let early_reuse = harness.submit(reserve(11, 22, 7, 4)).unwrap();
+    assert_eq!(early_reuse.outcome.result_code, ResultCode::ResourceBusy);
+
+    harness.advance_to(Slot(6));
+    let reclaimed = harness.submit(reclaim(3, 8)).unwrap();
+    assert_eq!(reclaimed.outcome.result_code, ResultCode::Ok);
+
+    for resource_id in [11, 12] {
+        let resource = harness
+            .engine()
+            .db()
+            .resource(ResourceId(resource_id))
+            .unwrap();
+        assert_eq!(resource.current_state, ResourceState::Available);
+        assert_eq!(resource.current_reservation_id, None);
+    }
+
+    harness.advance_to(Slot(7));
+    let regranted = harness.submit(reserve_bundle(&[11, 12], 22, 9, 4)).unwrap();
+    assert_eq!(regranted.outcome.result_code, ResultCode::Ok);
+    assert_eq!(regranted.outcome.reservation_id, Some(ReservationId(9)));
 }
 
 #[test]

--- a/docs/status.md
+++ b/docs/status.md
@@ -14,7 +14,7 @@
   - `M6` replication design: implemented
   - `M7` replicated core prototype: in progress
   - `M8` external cluster validation: in progress
-  - `M9` generic lease-kernel follow-on: `T07` merged, `T08` implementation in progress on issue branch
+  - `M9` generic lease-kernel follow-on: `T10` merged, `T11` broader regression coverage in progress
 - Latest completed implementation chunks:
   - `4156a80` `Bootstrap AllocDB core and docs`
   - `f84a641` `Add WAL file and snapshot recovery primitives`
@@ -34,9 +34,9 @@
     three-replica cluster runner, fault-control harness, and QEMU testbed around the real replica
     daemon; the first trusted-core bundle-commit slice with bundle membership, bundle-aware
     confirm/release/expire, and bundle regression coverage; the first fencing slice with
-    lease-epoch propagation, stale-holder rejection, and epoch-aware retry/read coverage; and the
-    active revoke/reclaim slice on the issue branch with `revoking` / `revoked` lifecycle support,
-    replay-safe recovery, and one replicated failover regression for no-early-reuse preservation
+    lease-epoch propagation, stale-holder rejection, and epoch-aware retry/read coverage; plus
+    replicated preservation for committed bundle membership and stale-holder rejection across
+    failover and suffix/snapshot rejoin
 
 ## What Exists
 
@@ -195,11 +195,9 @@
   - local cluster, qemu assets, Jepsen harness, and benchmarks: `cargo test -p allocdb-node local_cluster -- --nocapture`, `cargo test -p allocdb-node qemu_testbed -- --nocapture`, `cargo test -p allocdb-node jepsen -- --nocapture`, `cargo test -p allocdb-node --bin allocdb-jepsen -- --nocapture`, `cargo run -p allocdb-node --bin allocdb-jepsen -- plan`, `cargo run -p allocdb-bench -- --scenario all`
   - repo gate: `scripts/preflight.sh`
 ## Current Focus
-- PR `#82` merged the `#70` maintainability follow-up, including live KubeVirt
-  `reservation_contention-control` and full `1800s` `reservation_contention-crash-restart`
-  reruns on `allocdb-a` with `blockers=0`
-- `M9-T01` through `M9-T05` are merged on `main` via PR `#81`, and the planning issues are closed
-  on the `AllocDB` project
+- PR `#82` merged the `#70` maintainability follow-up, including live KubeVirt `reservation_contention-control`
+  and full `1800s` `reservation_contention-crash-restart` reruns on `allocdb-a` with `blockers=0`
+- `M9-T01` through `M9-T05` are merged on `main` via PR `#81`, and the planning issues are closed on the `AllocDB` project
 - PR `#89` merged `M9-T06` on `main`: the trusted core now supports atomic bundle reservation,
   explicit bundle membership records, bundle-aware confirm/release/expire, and bundle-aware
   snapshot/codec coverage while preserving the existing reservation compatibility surface
@@ -211,10 +209,12 @@
 - PR `#93` merged `M9-T09` on `main`: the node API and wire codec now expose the approved
   lease-centric surface with `get_lease`, flattened committed results, `current_lease_id`, and
   ordered `member_resource_ids`, while keeping the trusted-core naming and apply path intact
-- issue `#87` / `M9-T10` is the active implementation slice on the current branch: preserve
-  bundle ownership, fencing outcomes, and revoke safety across replication, failover, and replica
-  rejoin without introducing a second apply path
-- targeted validation on the active `#87` branch currently centers on `cargo test -p allocdb-node replicated_simulation -- --nocapture`,
-  `cargo test -p allocdb-node replica -- --nocapture`, and `./scripts/preflight.sh`
-- the active `#87` branch keeps the `T10` / `T11` boundary explicit: it proves replicated-path preservation for the approved lease primitives, while broader scenario expansion stays in `M9-T11`
-- the next planned code-bearing slice after `#87` remains `M9-T11` broader regression coverage
+- PR `#94` merged `M9-T10` on `main`: replication and failover now preserve committed bundle
+  membership plus stale-holder rejection without introducing a second apply path
+- issue `#88` / `M9-T11` is the active implementation slice on the current branch: broaden
+  deterministic simulation and replicated regression coverage for bundle retries, revoke races,
+  stale-holder rejection, crash recovery, and failover
+- targeted validation on the active `#88` branch currently centers on `cargo test -p allocdb-node simulation -- --nocapture`,
+  `cargo test -p allocdb-node replicated_simulation -- --nocapture`, and `./scripts/preflight.sh`
+- the active `#88` branch is the final planned `M9` code-bearing slice before any new milestone
+  planning


### PR DESCRIPTION
## Summary
- add deterministic simulation regressions for bundle retry/crash recovery and revoke/restart safety
- add a replicated failover regression for duplicate bundle retry on the promoted primary
- sync docs/status.md to mark #88 as the active M9-T11 hardening slice

## Validation
- cargo test -p allocdb-node simulation -- --nocapture
- cargo test -p allocdb-node replicated_simulation -- --nocapture
- ./scripts/preflight.sh

Closes #88
