### PR TITLE
test: extend Jepsen lease-safety coverage

### DIFF
--- a/crates/allocdb-node/src/bin/allocdb-jepsen/events.rs
+++ b/crates/allocdb-node/src/bin/allocdb-jepsen/events.rs
@@ -42,6 +42,7 @@ pub(super) enum ResourceReadObservation {
 pub(super) struct ReserveCommit {
     pub(super) applied_lsn: Lsn,
     pub(super) reservation_id: ReservationId,
+    pub(super) lease_epoch: u64,
 }
 
 #[derive(Clone, Copy)]
@@ -51,6 +52,35 @@ pub(super) struct ReserveEventSpec {
     pub(super) holder_id: HolderId,
     pub(super) request_slot: Slot,
     pub(super) ttl_slots: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct ReserveBundleEventSpec<'a> {
+    pub(super) operation_id: OperationId,
+    pub(super) resource_ids: &'a [ResourceId],
+    pub(super) holder_id: HolderId,
+    pub(super) request_slot: Slot,
+    pub(super) ttl_slots: u64,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct HolderLeaseEventSpec<'a> {
+    pub(super) kind: JepsenOperationKind,
+    pub(super) operation_id: OperationId,
+    pub(super) reservation_id: ReservationId,
+    pub(super) resource_id: ResourceId,
+    pub(super) resource_ids: &'a [ResourceId],
+    pub(super) holder_id: HolderId,
+    pub(super) lease_epoch: u64,
+    pub(super) request_slot: Slot,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct AdminLeaseEventSpec {
+    pub(super) kind: JepsenOperationKind,
+    pub(super) operation_id: OperationId,
+    pub(super) reservation_id: ReservationId,
+    pub(super) request_slot: Slot,
 }
 
 #[derive(Clone, Copy)]
@@ -100,8 +130,10 @@ pub(super) fn reserve_event<T: ExternalTestbed>(
         kind: JepsenOperationKind::Reserve,
         operation_id: Some(spec.operation_id.get()),
         resource_id: Some(spec.resource_id),
+        resource_ids: Vec::new(),
         reservation_id: None,
         holder_id: Some(spec.holder_id.get()),
+        lease_epoch: None,
         required_lsn: None,
         request_slot: Some(spec.request_slot),
         ttl_slots: Some(spec.ttl_slots),
@@ -135,6 +167,57 @@ pub(super) fn reserve_event<T: ExternalTestbed>(
     }
 }
 
+pub(super) fn reserve_bundle_event<T: ExternalTestbed>(
+    layout: &T,
+    replica: &LocalClusterReplicaConfig,
+    context: &RunExecutionContext,
+    spec: ReserveBundleEventSpec<'_>,
+) -> Result<(JepsenOperation, JepsenEventOutcome, Option<ReserveCommit>), String> {
+    let anchor_resource_id = *spec
+        .resource_ids
+        .first()
+        .ok_or_else(|| String::from("reserve_bundle requires at least one resource"))?;
+    let operation = JepsenOperation {
+        kind: JepsenOperationKind::ReserveBundle,
+        operation_id: Some(spec.operation_id.get()),
+        resource_id: Some(anchor_resource_id),
+        resource_ids: spec.resource_ids.to_vec(),
+        reservation_id: None,
+        holder_id: Some(spec.holder_id.get()),
+        lease_epoch: None,
+        required_lsn: None,
+        request_slot: Some(spec.request_slot),
+        ttl_slots: Some(spec.ttl_slots),
+    };
+    let request = ApiRequest::Submit(SubmitRequest::from_client_request(
+        context.slot(spec.request_slot.get()),
+        context.client_request(
+            spec.operation_id,
+            AllocCommand::ReserveBundle {
+                resource_ids: spec.resource_ids.to_vec(),
+                holder_id: spec.holder_id,
+                ttl_slots: spec.ttl_slots,
+            },
+        ),
+    ));
+    match send_replica_api_request(layout, replica, &request)? {
+        RemoteApiOutcome::Api(ApiResponse::Submit(response)) => {
+            map_reserve_submit_response(operation, anchor_resource_id, spec.holder_id, response)
+        }
+        RemoteApiOutcome::Api(other) => Err(format!(
+            "reserve_bundle returned unexpected response {other:?}"
+        )),
+        RemoteApiOutcome::Text(text) if response_text_is_not_primary(&text) => Ok((
+            operation,
+            JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::NotPrimary),
+            None,
+        )),
+        RemoteApiOutcome::Text(text) => Err(format!(
+            "reserve_bundle returned undecodable response {text}"
+        )),
+    }
+}
+
 pub(super) fn tick_expirations_event<T: ExternalTestbed>(
     layout: &T,
     replica: &LocalClusterReplicaConfig,
@@ -148,8 +231,10 @@ pub(super) fn tick_expirations_event<T: ExternalTestbed>(
         kind: JepsenOperationKind::TickExpirations,
         operation_id: Some(operation_id.get()),
         resource_id: None,
+        resource_ids: Vec::new(),
         reservation_id: None,
         holder_id: None,
+        lease_epoch: None,
         required_lsn: None,
         request_slot: Some(current_wall_clock_slot),
         ttl_slots: None,
@@ -212,8 +297,10 @@ pub(super) fn reservation_read_event<T: ExternalTestbed>(
         kind: JepsenOperationKind::GetReservation,
         operation_id: None,
         resource_id: None,
+        resource_ids: Vec::new(),
         reservation_id: Some(reservation_id.get()),
         holder_id: None,
+        lease_epoch: None,
         required_lsn,
         request_slot: Some(current_slot),
         ttl_slots: None,
@@ -380,6 +467,31 @@ pub(super) fn outcome_from_submission_failure(failure: &SubmissionFailure) -> Je
     JepsenEventOutcome::DefiniteFailure(failure)
 }
 
+fn definite_failure_from_result_code(result_code: ResultCode) -> Option<JepsenDefiniteFailure> {
+    match result_code {
+        ResultCode::ResourceBusy => Some(JepsenDefiniteFailure::Busy),
+        ResultCode::OperationConflict
+        | ResultCode::InvalidState
+        | ResultCode::HolderMismatch
+        | ResultCode::BundleTooLarge
+        | ResultCode::TtlOutOfRange
+        | ResultCode::ResourceTableFull
+        | ResultCode::ReservationTableFull
+        | ResultCode::ReservationMemberTableFull
+        | ResultCode::ExpirationIndexFull
+        | ResultCode::OperationTableFull
+        | ResultCode::SlotOverflow
+        | ResultCode::AlreadyExists
+        | ResultCode::Noop => Some(JepsenDefiniteFailure::Conflict),
+        ResultCode::StaleEpoch => Some(JepsenDefiniteFailure::StaleEpoch),
+        ResultCode::ResourceNotFound | ResultCode::ReservationNotFound => {
+            Some(JepsenDefiniteFailure::NotFound)
+        }
+        ResultCode::ReservationRetired => Some(JepsenDefiniteFailure::Retired),
+        ResultCode::Ok => None,
+    }
+}
+
 pub(super) fn primary_process_name(replica: &LocalClusterReplicaConfig) -> String {
     format!("primary-{}", replica.replica_id.get())
 }
@@ -412,6 +524,9 @@ fn map_reserve_submit_response(
                 let reservation_id = response
                     .lease_id
                     .ok_or_else(|| String::from("reserve commit missing reservation_id"))?;
+                let lease_epoch = response
+                    .lease_epoch
+                    .ok_or_else(|| String::from("reserve commit missing lease_epoch"))?;
                 let expires_at_slot = response
                     .deadline_slot
                     .ok_or_else(|| String::from("reserve commit missing deadline_slot"))?;
@@ -421,6 +536,7 @@ fn map_reserve_submit_response(
                         applied_lsn: response.applied_lsn,
                         result: JepsenWriteResult::Reserved {
                             resource_id,
+                            lease_epoch,
                             holder_id: holder_id.get(),
                             reservation_id: reservation_id.get(),
                             expires_at_slot,
@@ -429,33 +545,226 @@ fn map_reserve_submit_response(
                     Some(ReserveCommit {
                         applied_lsn: response.applied_lsn,
                         reservation_id,
+                        lease_epoch,
                     }),
                 ))
             }
-            ResultCode::ResourceBusy => Ok((
-                operation,
-                JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::Busy),
-                None,
-            )),
-            ResultCode::OperationConflict => Ok((
-                operation,
-                JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::Conflict),
-                None,
-            )),
-            ResultCode::ResourceNotFound | ResultCode::ReservationNotFound => Ok((
-                operation,
-                JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::NotFound),
-                None,
-            )),
-            ResultCode::ReservationRetired => Ok((
-                operation,
-                JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::Retired),
-                None,
-            )),
-            other => Err(format!("unexpected reserve result code {other:?}")),
+            other => definite_failure_from_result_code(other)
+                .map(|failure| {
+                    (
+                        operation,
+                        JepsenEventOutcome::DefiniteFailure(failure),
+                        None,
+                    )
+                })
+                .ok_or_else(|| format!("unexpected reserve result code {other:?}")),
         },
         SubmitResponse::Rejected(failure) => {
             Ok((operation, outcome_from_submission_failure(&failure), None))
+        }
+    }
+}
+
+pub(super) fn holder_lease_event<T: ExternalTestbed>(
+    layout: &T,
+    replica: &LocalClusterReplicaConfig,
+    context: &RunExecutionContext,
+    spec: HolderLeaseEventSpec<'_>,
+) -> Result<(JepsenOperation, JepsenEventOutcome), String> {
+    let operation = JepsenOperation {
+        kind: spec.kind,
+        operation_id: Some(spec.operation_id.get()),
+        resource_id: Some(spec.resource_id),
+        resource_ids: spec.resource_ids.to_vec(),
+        reservation_id: Some(spec.reservation_id.get()),
+        holder_id: Some(spec.holder_id.get()),
+        lease_epoch: Some(spec.lease_epoch),
+        required_lsn: None,
+        request_slot: Some(spec.request_slot),
+        ttl_slots: None,
+    };
+    let command = match spec.kind {
+        JepsenOperationKind::Confirm => AllocCommand::Confirm {
+            reservation_id: spec.reservation_id,
+            holder_id: spec.holder_id,
+            lease_epoch: spec.lease_epoch,
+        },
+        JepsenOperationKind::Release => AllocCommand::Release {
+            reservation_id: spec.reservation_id,
+            holder_id: spec.holder_id,
+            lease_epoch: spec.lease_epoch,
+        },
+        _ => {
+            return Err(format!(
+                "holder_lease_event does not support operation {:?}",
+                spec.kind
+            ));
+        }
+    };
+    let request = ApiRequest::Submit(SubmitRequest::from_client_request(
+        context.slot(spec.request_slot.get()),
+        context.client_request(spec.operation_id, command),
+    ));
+    match send_replica_api_request(layout, replica, &request)? {
+        RemoteApiOutcome::Api(ApiResponse::Submit(response)) => {
+            map_holder_submit_response(operation, response)
+        }
+        RemoteApiOutcome::Api(other) => Err(format!(
+            "holder lease operation returned unexpected response {other:?}"
+        )),
+        RemoteApiOutcome::Text(text) if response_text_is_not_primary(&text) => Ok((
+            operation,
+            JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::NotPrimary),
+        )),
+        RemoteApiOutcome::Text(text) => Err(format!(
+            "holder lease operation returned undecodable response {text}"
+        )),
+    }
+}
+
+pub(super) fn admin_lease_event<T: ExternalTestbed>(
+    layout: &T,
+    replica: &LocalClusterReplicaConfig,
+    context: &RunExecutionContext,
+    spec: AdminLeaseEventSpec,
+) -> Result<(JepsenOperation, JepsenEventOutcome), String> {
+    let operation = JepsenOperation {
+        kind: spec.kind,
+        operation_id: Some(spec.operation_id.get()),
+        resource_id: None,
+        resource_ids: Vec::new(),
+        reservation_id: Some(spec.reservation_id.get()),
+        holder_id: None,
+        lease_epoch: None,
+        required_lsn: None,
+        request_slot: Some(spec.request_slot),
+        ttl_slots: None,
+    };
+    let command = match spec.kind {
+        JepsenOperationKind::Revoke => AllocCommand::Revoke {
+            reservation_id: spec.reservation_id,
+        },
+        JepsenOperationKind::Reclaim => AllocCommand::Reclaim {
+            reservation_id: spec.reservation_id,
+        },
+        _ => {
+            return Err(format!(
+                "admin_lease_event does not support operation {:?}",
+                spec.kind
+            ));
+        }
+    };
+    let request = ApiRequest::Submit(SubmitRequest::from_client_request(
+        context.slot(spec.request_slot.get()),
+        context.client_request(spec.operation_id, command),
+    ));
+    match send_replica_api_request(layout, replica, &request)? {
+        RemoteApiOutcome::Api(ApiResponse::Submit(response)) => {
+            map_admin_submit_response(operation, response)
+        }
+        RemoteApiOutcome::Api(other) => Err(format!(
+            "admin lease operation returned unexpected response {other:?}"
+        )),
+        RemoteApiOutcome::Text(text) if response_text_is_not_primary(&text) => Ok((
+            operation,
+            JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::NotPrimary),
+        )),
+        RemoteApiOutcome::Text(text) => Err(format!(
+            "admin lease operation returned undecodable response {text}"
+        )),
+    }
+}
+
+fn map_holder_submit_response(
+    operation: JepsenOperation,
+    response: SubmitResponse,
+) -> Result<(JepsenOperation, JepsenEventOutcome), String> {
+    match response {
+        SubmitResponse::Committed(response) => match response.result_code {
+            ResultCode::Ok => {
+                let reservation_id = ReservationId(
+                    operation
+                        .reservation_id
+                        .ok_or_else(|| String::from("holder operation missing reservation_id"))?,
+                );
+                let holder_id = operation
+                    .holder_id
+                    .ok_or_else(|| String::from("holder operation missing holder_id"))?;
+                let resource_id = operation
+                    .resource_id
+                    .ok_or_else(|| String::from("holder operation missing resource_id"))?;
+                let result = match operation.kind {
+                    JepsenOperationKind::Confirm => JepsenWriteResult::Confirmed {
+                        resource_id,
+                        lease_epoch: operation
+                            .lease_epoch
+                            .ok_or_else(|| String::from("confirm missing lease_epoch"))?,
+                        holder_id,
+                        reservation_id: reservation_id.get(),
+                    },
+                    JepsenOperationKind::Release => JepsenWriteResult::Released {
+                        resource_id,
+                        holder_id,
+                        reservation_id: reservation_id.get(),
+                        released_lsn: Some(response.applied_lsn),
+                    },
+                    other => {
+                        return Err(format!(
+                            "holder operation mapper does not support result for {other:?}"
+                        ));
+                    }
+                };
+                Ok((
+                    operation,
+                    JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
+                        applied_lsn: response.applied_lsn,
+                        result,
+                    }),
+                ))
+            }
+            other => definite_failure_from_result_code(other)
+                .map(|failure| (operation, JepsenEventOutcome::DefiniteFailure(failure)))
+                .ok_or_else(|| format!("unexpected holder result code {other:?}")),
+        },
+        SubmitResponse::Rejected(failure) => {
+            Ok((operation, outcome_from_submission_failure(&failure)))
+        }
+    }
+}
+
+fn map_admin_submit_response(
+    operation: JepsenOperation,
+    response: SubmitResponse,
+) -> Result<(JepsenOperation, JepsenEventOutcome), String> {
+    match response {
+        SubmitResponse::Committed(response) => match response.result_code {
+            ResultCode::Ok => {
+                let reservation_id = operation
+                    .reservation_id
+                    .ok_or_else(|| String::from("admin operation missing reservation_id"))?;
+                let result = match operation.kind {
+                    JepsenOperationKind::Revoke => JepsenWriteResult::Revoked { reservation_id },
+                    JepsenOperationKind::Reclaim => JepsenWriteResult::Reclaimed { reservation_id },
+                    other => {
+                        return Err(format!(
+                            "admin operation mapper does not support result for {other:?}"
+                        ));
+                    }
+                };
+                Ok((
+                    operation,
+                    JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
+                        applied_lsn: response.applied_lsn,
+                        result,
+                    }),
+                ))
+            }
+            other => definite_failure_from_result_code(other)
+                .map(|failure| (operation, JepsenEventOutcome::DefiniteFailure(failure)))
+                .ok_or_else(|| format!("unexpected admin result code {other:?}")),
+        },
+        SubmitResponse::Rejected(failure) => {
+            Ok((operation, outcome_from_submission_failure(&failure)))
         }
     }
 }
@@ -558,8 +867,10 @@ fn resource_available_event<T: ExternalTestbed>(
         kind: JepsenOperationKind::GetResource,
         operation_id: None,
         resource_id: Some(resource_id),
+        resource_ids: Vec::new(),
         reservation_id: None,
         holder_id: None,
+        lease_epoch: None,
         required_lsn,
         request_slot: None,
         ttl_slots: None,
@@ -733,8 +1044,10 @@ mod tests {
             kind: JepsenOperationKind::Reserve,
             operation_id: Some(9),
             resource_id: Some(ResourceId(7)),
+            resource_ids: Vec::new(),
             reservation_id: None,
             holder_id: Some(11),
+            lease_epoch: None,
             required_lsn: None,
             request_slot: Some(Slot(3)),
             ttl_slots: Some(5),
@@ -756,9 +1069,10 @@ mod tests {
             SubmitResponse::Committed(
                 SubmissionResult {
                     applied_lsn: Lsn(21),
-                    outcome: CommandOutcome::with_reservation(
+                    outcome: CommandOutcome::with_reservation_epoch(
                         ResultCode::Ok,
                         ReservationId(31),
+                        1,
                         Slot(99),
                     ),
                     from_retry_cache: false,
@@ -805,6 +1119,123 @@ mod tests {
         assert_eq!(
             retired.1,
             JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::Retired)
+        );
+    }
+
+    #[test]
+    fn map_holder_submit_response_maps_confirm_and_stale_epoch() {
+        let operation = JepsenOperation {
+            kind: JepsenOperationKind::Confirm,
+            operation_id: Some(19),
+            resource_id: Some(ResourceId(7)),
+            resource_ids: vec![ResourceId(7), ResourceId(8)],
+            reservation_id: Some(31),
+            holder_id: Some(11),
+            lease_epoch: Some(2),
+            required_lsn: None,
+            request_slot: Some(Slot(5)),
+            ttl_slots: None,
+        };
+
+        let committed = map_holder_submit_response(
+            operation.clone(),
+            SubmitResponse::Committed(
+                SubmissionResult {
+                    applied_lsn: Lsn(21),
+                    outcome: CommandOutcome::new(ResultCode::Ok),
+                    from_retry_cache: false,
+                }
+                .into(),
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            committed.1,
+            JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
+                applied_lsn: Lsn(21),
+                result: JepsenWriteResult::Confirmed {
+                    resource_id: ResourceId(7),
+                    lease_epoch: 2,
+                    holder_id: 11,
+                    reservation_id: 31,
+                },
+            })
+        );
+
+        let stale = map_holder_submit_response(
+            operation,
+            SubmitResponse::Committed(
+                SubmissionResult {
+                    applied_lsn: Lsn(22),
+                    outcome: CommandOutcome::new(ResultCode::StaleEpoch),
+                    from_retry_cache: false,
+                }
+                .into(),
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            stale.1,
+            JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::StaleEpoch)
+        );
+    }
+
+    #[test]
+    fn map_admin_submit_response_maps_revoke_and_reclaim() {
+        let revoke_operation = JepsenOperation {
+            kind: JepsenOperationKind::Revoke,
+            operation_id: Some(29),
+            resource_id: None,
+            resource_ids: Vec::new(),
+            reservation_id: Some(41),
+            holder_id: None,
+            lease_epoch: None,
+            required_lsn: None,
+            request_slot: Some(Slot(6)),
+            ttl_slots: None,
+        };
+
+        let revoke = map_admin_submit_response(
+            revoke_operation.clone(),
+            SubmitResponse::Committed(
+                SubmissionResult {
+                    applied_lsn: Lsn(31),
+                    outcome: CommandOutcome::new(ResultCode::Ok),
+                    from_retry_cache: false,
+                }
+                .into(),
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            revoke.1,
+            JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
+                applied_lsn: Lsn(31),
+                result: JepsenWriteResult::Revoked { reservation_id: 41 },
+            })
+        );
+
+        let reclaim = map_admin_submit_response(
+            JepsenOperation {
+                kind: JepsenOperationKind::Reclaim,
+                ..revoke_operation
+            },
+            SubmitResponse::Committed(
+                SubmissionResult {
+                    applied_lsn: Lsn(32),
+                    outcome: CommandOutcome::new(ResultCode::Ok),
+                    from_retry_cache: false,
+                }
+                .into(),
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            reclaim.1,
+            JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
+                applied_lsn: Lsn(32),
+                result: JepsenWriteResult::Reclaimed { reservation_id: 41 },
+            })
         );
     }
 

--- a/crates/allocdb-node/src/bin/allocdb-jepsen/nemesis.rs
+++ b/crates/allocdb-node/src/bin/allocdb-jepsen/nemesis.rs
@@ -58,6 +58,9 @@ pub(super) fn execute_partition_heal_run<T: ExternalTestbed>(
             base_id,
             context,
         ),
+        JepsenWorkloadFamily::LeaseSafety => Err(String::from(
+            "partition-heal runs are not defined for lease_safety",
+        )),
     }
 }
 
@@ -98,6 +101,9 @@ pub(super) fn execute_mixed_failover_run<T: ExternalTestbed>(
             base_id,
             context,
         ),
+        JepsenWorkloadFamily::LeaseSafety => Err(String::from(
+            "mixed failover runs are not defined for lease_safety",
+        )),
     }
 }
 

--- a/crates/allocdb-node/src/bin/allocdb-jepsen/runs.rs
+++ b/crates/allocdb-node/src/bin/allocdb-jepsen/runs.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use allocdb_node::jepsen::{
     JepsenHistoryEvent, JepsenNemesisFamily, JepsenRunSpec, analyze_history,
-    create_artifact_bundle, load_history, persist_history, release_gate_plan,
-    render_analysis_report,
+    create_artifact_bundle, load_history, persist_history, render_analysis_report,
+    supported_run_plan,
 };
 
 use super::kubevirt::{load_kubevirt_layout, prepare_kubevirt_helper};
@@ -59,7 +59,7 @@ pub(super) fn archive_kubevirt_run(
 }
 
 pub(super) fn resolve_run_spec(run_id: &str) -> Result<JepsenRunSpec, String> {
-    release_gate_plan()
+    supported_run_plan()
         .into_iter()
         .find(|candidate| candidate.run_id == run_id)
         .ok_or_else(|| format!("unknown Jepsen run id `{run_id}`"))

--- a/crates/allocdb-node/src/bin/allocdb-jepsen/scenarios.rs
+++ b/crates/allocdb-node/src/bin/allocdb-jepsen/scenarios.rs
@@ -1,6 +1,7 @@
 use allocdb_core::ids::{HolderId, OperationId, ResourceId, Slot};
 use allocdb_node::jepsen::{
-    JepsenExpiredReservation, JepsenHistoryEvent, JepsenRunSpec, JepsenWorkloadFamily,
+    JepsenExpiredReservation, JepsenHistoryEvent, JepsenOperationKind, JepsenRunSpec,
+    JepsenWorkloadFamily,
 };
 use allocdb_node::local_cluster::LocalClusterReplicaConfig;
 
@@ -9,9 +10,10 @@ use crate::cluster::{
     runtime_replica_by_id,
 };
 use crate::events::{
-    ExpirationDrainPlan, ReserveEventSpec, backup_process_name, create_qemu_resource,
-    primary_process_name, record_resource_available_after_expiration, reservation_read_event,
-    reserve_event, tick_expirations_event,
+    AdminLeaseEventSpec, ExpirationDrainPlan, HolderLeaseEventSpec, ReserveBundleEventSpec,
+    ReserveCommit, ReserveEventSpec, admin_lease_event, backup_process_name, create_qemu_resource,
+    holder_lease_event, primary_process_name, record_resource_available_after_expiration,
+    reservation_read_event, reserve_bundle_event, reserve_event, tick_expirations_event,
 };
 use crate::support::{HistoryBuilder, RunExecutionContext};
 use crate::{ExternalTestbed, unique_probe_resource_id};
@@ -37,6 +39,7 @@ pub(super) fn execute_control_run<T: ExternalTestbed>(
         JepsenWorkloadFamily::ExpirationAndRecovery => {
             run_expiration_and_recovery(layout, &primary, base_id, context)
         }
+        JepsenWorkloadFamily::LeaseSafety => run_lease_safety(layout, &primary, base_id, context),
     }
 }
 
@@ -75,6 +78,14 @@ pub(super) fn execute_crash_restart_run<T: ExternalTestbed>(
             context,
         ),
         JepsenWorkloadFamily::ExpirationAndRecovery => run_crash_restart_expiration_recovery(
+            layout,
+            &primary,
+            &failover_target,
+            &supporting_backup,
+            base_id,
+            context,
+        ),
+        JepsenWorkloadFamily::LeaseSafety => run_crash_restart_lease_safety(
             layout,
             &primary,
             &failover_target,
@@ -399,6 +410,222 @@ fn run_crash_restart_expiration_recovery<T: ExternalTestbed>(
     Ok(history.finish())
 }
 
+struct LeaseSafetySetup {
+    resource_ids: [ResourceId; 2],
+    reserve_commit: ReserveCommit,
+}
+
+fn lease_safety_resource_ids(base_id: u128) -> [ResourceId; 2] {
+    [ResourceId(base_id + 4), ResourceId(base_id + 5)]
+}
+
+fn create_lease_safety_resources<T: ExternalTestbed>(
+    layout: &T,
+    primary: &LocalClusterReplicaConfig,
+    context: &RunExecutionContext,
+    base_id: u128,
+) -> Result<[ResourceId; 2], String> {
+    let resource_ids = lease_safety_resource_ids(base_id);
+    for (offset, resource_id) in resource_ids.iter().enumerate() {
+        create_qemu_resource(
+            layout,
+            primary,
+            context,
+            *resource_id,
+            OperationId(base_id + 104 + u128::try_from(offset).expect("offset fits u128")),
+        )?;
+    }
+    Ok(resource_ids)
+}
+
+fn prepare_lease_safety_setup<T: ExternalTestbed>(
+    layout: &T,
+    primary: &LocalClusterReplicaConfig,
+    context: &RunExecutionContext,
+    history: &mut HistoryBuilder,
+    base_id: u128,
+    reserve_error_context: &str,
+) -> Result<LeaseSafetySetup, String> {
+    let resource_ids = create_lease_safety_resources(layout, primary, context, base_id)?;
+    let (reserve_operation, reserve_outcome, reserve_commit) = reserve_bundle_event(
+        layout,
+        primary,
+        context,
+        ReserveBundleEventSpec {
+            operation_id: OperationId(base_id + 40),
+            resource_ids: &resource_ids,
+            holder_id: HolderId(808),
+            request_slot: Slot(70),
+            ttl_slots: 8,
+        },
+    )?;
+    let reserve_commit = reserve_commit
+        .ok_or_else(|| format!("{reserve_error_context} expected one committed bundle reserve"))?;
+    history.push(
+        primary_process_name(primary),
+        reserve_operation,
+        reserve_outcome,
+    );
+
+    let confirm = holder_lease_event(
+        layout,
+        primary,
+        context,
+        HolderLeaseEventSpec {
+            kind: JepsenOperationKind::Confirm,
+            operation_id: OperationId(base_id + 41),
+            reservation_id: reserve_commit.reservation_id,
+            resource_id: resource_ids[0],
+            resource_ids: &resource_ids,
+            holder_id: HolderId(808),
+            lease_epoch: reserve_commit.lease_epoch,
+            request_slot: Slot(71),
+        },
+    )?;
+    history.push(primary_process_name(primary), confirm.0, confirm.1);
+
+    Ok(LeaseSafetySetup {
+        resource_ids,
+        reserve_commit,
+    })
+}
+
+fn record_lease_safety_revoke_cycle<T: ExternalTestbed>(
+    layout: &T,
+    primary: &LocalClusterReplicaConfig,
+    context: &RunExecutionContext,
+    history: &mut HistoryBuilder,
+    base_id: u128,
+    setup: &LeaseSafetySetup,
+) -> Result<(), String> {
+    let revoke = admin_lease_event(
+        layout,
+        primary,
+        context,
+        AdminLeaseEventSpec {
+            kind: JepsenOperationKind::Revoke,
+            operation_id: OperationId(base_id + 42),
+            reservation_id: setup.reserve_commit.reservation_id,
+            request_slot: Slot(72),
+        },
+    )?;
+    history.push(primary_process_name(primary), revoke.0, revoke.1);
+
+    let stale_release = holder_lease_event(
+        layout,
+        primary,
+        context,
+        HolderLeaseEventSpec {
+            kind: JepsenOperationKind::Release,
+            operation_id: OperationId(base_id + 43),
+            reservation_id: setup.reserve_commit.reservation_id,
+            resource_id: setup.resource_ids[0],
+            resource_ids: &setup.resource_ids,
+            holder_id: HolderId(808),
+            lease_epoch: setup.reserve_commit.lease_epoch,
+            request_slot: Slot(73),
+        },
+    )?;
+    history.push(
+        primary_process_name(primary),
+        stale_release.0,
+        stale_release.1,
+    );
+
+    let pre_reclaim_retry = reserve_bundle_event(
+        layout,
+        primary,
+        context,
+        ReserveBundleEventSpec {
+            operation_id: OperationId(base_id + 44),
+            resource_ids: &setup.resource_ids,
+            holder_id: HolderId(809),
+            request_slot: Slot(74),
+            ttl_slots: 6,
+        },
+    )?;
+    history.push(
+        primary_process_name(primary),
+        pre_reclaim_retry.0,
+        pre_reclaim_retry.1,
+    );
+
+    let reclaim = admin_lease_event(
+        layout,
+        primary,
+        context,
+        AdminLeaseEventSpec {
+            kind: JepsenOperationKind::Reclaim,
+            operation_id: OperationId(base_id + 45),
+            reservation_id: setup.reserve_commit.reservation_id,
+            request_slot: Slot(75),
+        },
+    )?;
+    history.push(primary_process_name(primary), reclaim.0, reclaim.1);
+
+    let post_reclaim_reserve = reserve_bundle_event(
+        layout,
+        primary,
+        context,
+        ReserveBundleEventSpec {
+            operation_id: OperationId(base_id + 46),
+            resource_ids: &setup.resource_ids,
+            holder_id: HolderId(810),
+            request_slot: Slot(76),
+            ttl_slots: 4,
+        },
+    )?;
+    history.push(
+        primary_process_name(primary),
+        post_reclaim_reserve.0,
+        post_reclaim_reserve.1,
+    );
+    Ok(())
+}
+
+fn run_crash_restart_lease_safety<T: ExternalTestbed>(
+    layout: &T,
+    primary: &LocalClusterReplicaConfig,
+    failover_target: &LocalClusterReplicaConfig,
+    supporting_backup: &LocalClusterReplicaConfig,
+    base_id: u128,
+    context: &RunExecutionContext,
+) -> Result<Vec<JepsenHistoryEvent>, String> {
+    let mut history = HistoryBuilder::new(
+        Some(context.tracker.clone()),
+        context.history_sequence_start,
+    );
+    let lease_setup = prepare_lease_safety_setup(
+        layout,
+        primary,
+        context,
+        &mut history,
+        base_id,
+        "crash-restart lease_safety",
+    )?;
+
+    maybe_crash_replica(layout, primary.replica_id)?;
+    perform_failover(
+        layout,
+        primary.replica_id,
+        failover_target.replica_id,
+        supporting_backup.replica_id,
+    )?;
+
+    let current_primary = primary_replica(layout)?;
+    record_lease_safety_revoke_cycle(
+        layout,
+        &current_primary,
+        context,
+        &mut history,
+        base_id,
+        &lease_setup,
+    )?;
+
+    perform_rejoin(layout, current_primary.replica_id, primary.replica_id)?;
+    Ok(history.finish())
+}
+
 fn run_reservation_contention<T: ExternalTestbed>(
     layout: &T,
     primary: &LocalClusterReplicaConfig,
@@ -654,5 +881,34 @@ fn run_expiration_and_recovery<T: ExternalTestbed>(
         reservation_read.0,
         reservation_read.1,
     );
+    Ok(history.finish())
+}
+
+fn run_lease_safety<T: ExternalTestbed>(
+    layout: &T,
+    primary: &LocalClusterReplicaConfig,
+    base_id: u128,
+    context: &RunExecutionContext,
+) -> Result<Vec<JepsenHistoryEvent>, String> {
+    let mut history = HistoryBuilder::new(
+        Some(context.tracker.clone()),
+        context.history_sequence_start,
+    );
+    let lease_setup = prepare_lease_safety_setup(
+        layout,
+        primary,
+        context,
+        &mut history,
+        base_id,
+        "lease_safety control run",
+    )?;
+    record_lease_safety_revoke_cycle(
+        layout,
+        primary,
+        context,
+        &mut history,
+        base_id,
+        &lease_setup,
+    )?;
     Ok(history.finish())
 }

--- a/crates/allocdb-node/src/bin/allocdb-jepsen/surface.rs
+++ b/crates/allocdb-node/src/bin/allocdb-jepsen/surface.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use allocdb_core::ids::ResourceId;
 use allocdb_node::jepsen::{
-    analyze_history, load_history, release_gate_plan, render_analysis_report,
+    analyze_history, load_history, render_analysis_report, supported_run_plan,
 };
 use allocdb_node::kubevirt_testbed::KubevirtTestbedLayout;
 use allocdb_node::local_cluster::LocalClusterLayout;
@@ -103,7 +103,7 @@ impl ExternalTestbed for KubevirtTestbedLayout {
 }
 
 pub(super) fn print_release_gate_plan() {
-    for run in release_gate_plan() {
+    for run in supported_run_plan() {
         println!(
             "run_id={} workload={} nemesis={} minimum_fault_window_secs={} release_blocking={}",
             run.run_id,

--- a/crates/allocdb-node/src/bin/allocdb-jepsen/tests.rs
+++ b/crates/allocdb-node/src/bin/allocdb-jepsen/tests.rs
@@ -105,6 +105,41 @@ fn test_faulted_replica_status(
     status
 }
 
+fn reserve_operation(
+    operation_id: u128,
+    resource_id: ResourceId,
+    holder_id: u128,
+    request_slot: u64,
+) -> JepsenOperation {
+    JepsenOperation {
+        kind: JepsenOperationKind::Reserve,
+        operation_id: Some(operation_id),
+        resource_id: Some(resource_id),
+        resource_ids: Vec::new(),
+        reservation_id: None,
+        holder_id: Some(holder_id),
+        lease_epoch: None,
+        required_lsn: None,
+        request_slot: Some(Slot(request_slot)),
+        ttl_slots: Some(2),
+    }
+}
+
+fn reservation_read_operation(reservation_id: ReservationId, required_lsn: Lsn) -> JepsenOperation {
+    JepsenOperation {
+        kind: JepsenOperationKind::GetReservation,
+        operation_id: None,
+        resource_id: None,
+        resource_ids: Vec::new(),
+        reservation_id: Some(reservation_id.get()),
+        holder_id: None,
+        lease_epoch: None,
+        required_lsn: Some(required_lsn),
+        request_slot: Some(Slot(54)),
+        ttl_slots: None,
+    }
+}
+
 #[test]
 fn release_gate_plan_includes_faulted_qemu_runs() {
     let runs = release_gate_plan();
@@ -309,6 +344,10 @@ fn resolve_run_spec_and_minimum_fault_window_are_enforced() {
     assert!(error.contains("fault window"));
     assert!(error.contains("reservation_contention-crash-restart"));
 
+    let lease_safety = resolve_run_spec("lease_safety-control").unwrap();
+    assert_eq!(lease_safety.workload, JepsenWorkloadFamily::LeaseSafety);
+    assert!(!lease_safety.release_blocking);
+
     let unknown = resolve_run_spec("missing-run").unwrap_err();
     assert!(unknown.contains("unknown Jepsen run id"));
 }
@@ -472,8 +511,10 @@ fn history_builder_preserves_nonzero_sequence_offsets() {
             kind: JepsenOperationKind::Reserve,
             operation_id: Some(11),
             resource_id: Some(ResourceId(21)),
+            resource_ids: Vec::new(),
             reservation_id: None,
             holder_id: Some(31),
+            lease_epoch: None,
             required_lsn: None,
             request_slot: Some(Slot(41)),
             ttl_slots: Some(5),
@@ -486,8 +527,10 @@ fn history_builder_preserves_nonzero_sequence_offsets() {
             kind: JepsenOperationKind::Reserve,
             operation_id: Some(12),
             resource_id: Some(ResourceId(22)),
+            resource_ids: Vec::new(),
             reservation_id: None,
             holder_id: Some(32),
+            lease_epoch: None,
             required_lsn: None,
             request_slot: Some(Slot(42)),
             ttl_slots: Some(5),
@@ -510,20 +553,12 @@ fn analyzer_accepts_failover_read_fence_history_once_ambiguity_is_retried() {
     let mut history = HistoryBuilder::new(None, 0);
     history.push(
         "primary-1",
-        JepsenOperation {
-            kind: JepsenOperationKind::Reserve,
-            operation_id: Some(reserve_operation_id),
-            resource_id: Some(resource_id),
-            reservation_id: None,
-            holder_id: Some(604),
-            required_lsn: None,
-            request_slot: Some(Slot(53)),
-            ttl_slots: Some(6),
-        },
+        reserve_operation(reserve_operation_id, resource_id, 604, 53),
         JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
             applied_lsn: committed_lsn,
             result: JepsenWriteResult::Reserved {
                 resource_id,
+                lease_epoch: 1,
                 holder_id: 604,
                 reservation_id: reservation_id.get(),
                 expires_at_slot: Slot(900),
@@ -532,30 +567,12 @@ fn analyzer_accepts_failover_read_fence_history_once_ambiguity_is_retried() {
     );
     history.push(
         "primary-1",
-        JepsenOperation {
-            kind: JepsenOperationKind::Reserve,
-            operation_id: Some(ambiguous_operation_id),
-            resource_id: Some(resource_id),
-            reservation_id: None,
-            holder_id: Some(605),
-            required_lsn: None,
-            request_slot: Some(Slot(54)),
-            ttl_slots: Some(2),
-        },
+        reserve_operation(ambiguous_operation_id, resource_id, 605, 54),
         JepsenEventOutcome::Ambiguous(JepsenAmbiguousOutcome::IndefiniteWrite),
     );
     history.push(
         "primary-2",
-        JepsenOperation {
-            kind: JepsenOperationKind::GetReservation,
-            operation_id: None,
-            resource_id: None,
-            reservation_id: Some(reservation_id.get()),
-            holder_id: None,
-            required_lsn: Some(committed_lsn),
-            request_slot: Some(Slot(54)),
-            ttl_slots: None,
-        },
+        reservation_read_operation(reservation_id, committed_lsn),
         JepsenEventOutcome::SuccessfulRead(JepsenSuccessfulRead {
             target: JepsenReadTarget::Reservation,
             served_by: ReplicaId(2),
@@ -571,30 +588,12 @@ fn analyzer_accepts_failover_read_fence_history_once_ambiguity_is_retried() {
     );
     history.push(
         "primary-2",
-        JepsenOperation {
-            kind: JepsenOperationKind::Reserve,
-            operation_id: Some(ambiguous_operation_id),
-            resource_id: Some(resource_id),
-            reservation_id: None,
-            holder_id: Some(605),
-            required_lsn: None,
-            request_slot: Some(Slot(54)),
-            ttl_slots: Some(2),
-        },
+        reserve_operation(ambiguous_operation_id, resource_id, 605, 54),
         JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::Conflict),
     );
     history.push(
         "backup-1",
-        JepsenOperation {
-            kind: JepsenOperationKind::GetReservation,
-            operation_id: None,
-            resource_id: None,
-            reservation_id: Some(reservation_id.get()),
-            holder_id: None,
-            required_lsn: Some(committed_lsn),
-            request_slot: Some(Slot(54)),
-            ttl_slots: None,
-        },
+        reservation_read_operation(reservation_id, committed_lsn),
         JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::NotPrimary),
     );
 

--- a/crates/allocdb-node/src/jepsen.rs
+++ b/crates/allocdb-node/src/jepsen.rs
@@ -24,6 +24,7 @@ pub enum JepsenWorkloadFamily {
     AmbiguousWriteRetry,
     FailoverReadFences,
     ExpirationAndRecovery,
+    LeaseSafety,
 }
 
 impl JepsenWorkloadFamily {
@@ -34,6 +35,7 @@ impl JepsenWorkloadFamily {
             Self::AmbiguousWriteRetry => "ambiguous_write_retry",
             Self::FailoverReadFences => "failover_read_fences",
             Self::ExpirationAndRecovery => "expiration_and_recovery",
+            Self::LeaseSafety => "lease_safety",
         }
     }
 
@@ -49,6 +51,7 @@ impl JepsenWorkloadFamily {
             "ambiguous_write_retry" => Ok(Self::AmbiguousWriteRetry),
             "failover_read_fences" => Ok(Self::FailoverReadFences),
             "expiration_and_recovery" => Ok(Self::ExpirationAndRecovery),
+            "lease_safety" => Ok(Self::LeaseSafety),
             other => Err(JepsenCodecError::InvalidField {
                 field: String::from("workload"),
                 value: String::from(other),
@@ -153,11 +156,41 @@ pub fn release_gate_plan() -> Vec<JepsenRunSpec> {
     runs
 }
 
+#[must_use]
+pub fn lease_coverage_plan() -> Vec<JepsenRunSpec> {
+    vec![
+        JepsenRunSpec {
+            run_id: String::from("lease_safety-control"),
+            workload: JepsenWorkloadFamily::LeaseSafety,
+            nemesis: JepsenNemesisFamily::None,
+            minimum_fault_window_secs: None,
+            release_blocking: false,
+        },
+        JepsenRunSpec {
+            run_id: String::from("lease_safety-crash-restart"),
+            workload: JepsenWorkloadFamily::LeaseSafety,
+            nemesis: JepsenNemesisFamily::CrashRestart,
+            minimum_fault_window_secs: Some(30 * 60),
+            release_blocking: false,
+        },
+    ]
+}
+
+#[must_use]
+pub fn supported_run_plan() -> Vec<JepsenRunSpec> {
+    let mut runs = release_gate_plan();
+    runs.extend(lease_coverage_plan());
+    runs
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum JepsenOperationKind {
     Reserve,
+    ReserveBundle,
     Confirm,
     Release,
+    Revoke,
+    Reclaim,
     TickExpirations,
     GetResource,
     GetReservation,
@@ -168,8 +201,11 @@ impl JepsenOperationKind {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::Reserve => "reserve",
+            Self::ReserveBundle => "reserve_bundle",
             Self::Confirm => "confirm",
             Self::Release => "release",
+            Self::Revoke => "revoke",
+            Self::Reclaim => "reclaim",
             Self::TickExpirations => "tick_expirations",
             Self::GetResource => "get_resource",
             Self::GetReservation => "get_reservation",
@@ -185,8 +221,11 @@ impl JepsenOperationKind {
     pub fn parse(value: &str) -> Result<Self, JepsenCodecError> {
         match value {
             "reserve" => Ok(Self::Reserve),
+            "reserve_bundle" => Ok(Self::ReserveBundle),
             "confirm" => Ok(Self::Confirm),
             "release" => Ok(Self::Release),
+            "revoke" => Ok(Self::Revoke),
+            "reclaim" => Ok(Self::Reclaim),
             "tick_expirations" => Ok(Self::TickExpirations),
             "get_resource" => Ok(Self::GetResource),
             "get_reservation" => Ok(Self::GetReservation),
@@ -201,7 +240,13 @@ impl JepsenOperationKind {
     pub const fn is_mutating(self) -> bool {
         matches!(
             self,
-            Self::Reserve | Self::Confirm | Self::Release | Self::TickExpirations
+            Self::Reserve
+                | Self::ReserveBundle
+                | Self::Confirm
+                | Self::Release
+                | Self::Revoke
+                | Self::Reclaim
+                | Self::TickExpirations
         )
     }
 }
@@ -211,8 +256,10 @@ pub struct JepsenOperation {
     pub kind: JepsenOperationKind,
     pub operation_id: Option<u128>,
     pub resource_id: Option<ResourceId>,
+    pub resource_ids: Vec<ResourceId>,
     pub reservation_id: Option<u128>,
     pub holder_id: Option<u128>,
+    pub lease_epoch: Option<u64>,
     pub required_lsn: Option<Lsn>,
     pub request_slot: Option<Slot>,
     pub ttl_slots: Option<u64>,
@@ -267,12 +314,14 @@ impl JepsenOutcomeKind {
 pub enum JepsenWriteResult {
     Reserved {
         resource_id: ResourceId,
+        lease_epoch: u64,
         holder_id: u128,
         reservation_id: u128,
         expires_at_slot: Slot,
     },
     Confirmed {
         resource_id: ResourceId,
+        lease_epoch: u64,
         holder_id: u128,
         reservation_id: u128,
     },
@@ -281,6 +330,12 @@ pub enum JepsenWriteResult {
         holder_id: u128,
         reservation_id: u128,
         released_lsn: Option<Lsn>,
+    },
+    Revoked {
+        reservation_id: u128,
+    },
+    Reclaimed {
+        reservation_id: u128,
     },
     TickExpired {
         expired: Vec<JepsenExpiredReservation>,
@@ -294,6 +349,8 @@ impl JepsenWriteResult {
             Self::Reserved { .. } => "reserved",
             Self::Confirmed { .. } => "confirmed",
             Self::Released { .. } => "released",
+            Self::Revoked { .. } => "revoked",
+            Self::Reclaimed { .. } => "reclaimed",
             Self::TickExpired { .. } => "tick_expired",
         }
     }
@@ -418,6 +475,7 @@ pub struct JepsenSuccessfulRead {
 pub enum JepsenDefiniteFailure {
     Busy,
     Conflict,
+    StaleEpoch,
     NotFound,
     Retired,
     FenceNotApplied,
@@ -432,6 +490,7 @@ impl JepsenDefiniteFailure {
         match self {
             Self::Busy => "busy",
             Self::Conflict => "conflict",
+            Self::StaleEpoch => "stale_epoch",
             Self::NotFound => "not_found",
             Self::Retired => "retired",
             Self::FenceNotApplied => "fence_not_applied",
@@ -451,6 +510,7 @@ impl JepsenDefiniteFailure {
         match value {
             "busy" => Ok(Self::Busy),
             "conflict" => Ok(Self::Conflict),
+            "stale_epoch" => Ok(Self::StaleEpoch),
             "not_found" => Ok(Self::NotFound),
             "retired" => Ok(Self::Retired),
             "fence_not_applied" => Ok(Self::FenceNotApplied),
@@ -566,6 +626,12 @@ pub enum JepsenBlockingIssue {
         existing_operation_id: u128,
         conflicting_operation_id: u128,
     },
+    StaleHolderNotRejected {
+        reservation_id: u128,
+        operation_id: u128,
+        attempted_epoch: u64,
+        current_epoch: u64,
+    },
     StaleSuccessfulRead(JepsenReadViolation),
     EarlyExpirationRelease {
         resource_id: ResourceId,
@@ -633,12 +699,14 @@ impl fmt::Display for JepsenCodecError {
 
 impl std::error::Error for JepsenCodecError {}
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CommittedFingerprint {
     pub applied_lsn: Lsn,
     pub resource_id: Option<ResourceId>,
+    pub resource_ids: Vec<ResourceId>,
     pub reservation_id: Option<u128>,
     pub holder_id: Option<u128>,
+    pub lease_epoch: Option<u64>,
     pub released_lsn: Option<Lsn>,
     pub expires_at_slot: Option<Slot>,
 }
@@ -744,6 +812,7 @@ pub fn persist_artifact_manifest(
 pub fn analyze_history(events: &[JepsenHistoryEvent]) -> JepsenAnalysisReport {
     let (builders, committed, mut blockers) = collect_mutating_attempts(events);
     blockers.extend(check_successful_reads(events));
+    blockers.extend(check_stale_holder_rejection(events));
     blockers.extend(unresolved_ambiguity_blockers(&builders));
     blockers.extend(check_committed_release_blockers(committed));
     JepsenAnalysisReport {
@@ -839,51 +908,72 @@ fn encode_history_event(event: &JepsenHistoryEvent) -> String {
         format!("time_millis={}", event.time_millis),
         format!("operation={}", event.operation.kind.as_str()),
     ];
-    if let Some(operation_id) = event.operation.operation_id {
+    encode_operation_tokens(&event.operation, &mut tokens);
+    tokens.push(format!("outcome={}", event.outcome.kind().as_str()));
+    encode_outcome_tokens(&event.outcome, &mut tokens);
+    tokens.join(" ")
+}
+
+fn encode_operation_tokens(operation: &JepsenOperation, tokens: &mut Vec<String>) {
+    if let Some(operation_id) = operation.operation_id {
         tokens.push(format!("operation_id={operation_id}"));
     }
-    if let Some(resource_id) = event.operation.resource_id {
+    if let Some(resource_id) = operation.resource_id {
         tokens.push(format!("resource_id={}", resource_id.get()));
     }
-    if let Some(reservation_id) = event.operation.reservation_id {
+    if !operation.resource_ids.is_empty() {
+        tokens.push(format!(
+            "resource_ids={}",
+            encode_resource_ids(&operation.resource_ids)
+        ));
+    }
+    if let Some(reservation_id) = operation.reservation_id {
         tokens.push(format!("reservation_id={reservation_id}"));
     }
-    if let Some(holder_id) = event.operation.holder_id {
+    if let Some(holder_id) = operation.holder_id {
         tokens.push(format!("holder_id={holder_id}"));
     }
-    if let Some(required_lsn) = event.operation.required_lsn {
+    if let Some(lease_epoch) = operation.lease_epoch {
+        tokens.push(format!("lease_epoch={lease_epoch}"));
+    }
+    if let Some(required_lsn) = operation.required_lsn {
         tokens.push(format!("required_lsn={}", required_lsn.get()));
     }
-    if let Some(request_slot) = event.operation.request_slot {
+    if let Some(request_slot) = operation.request_slot {
         tokens.push(format!("request_slot={}", request_slot.get()));
     }
-    if let Some(ttl_slots) = event.operation.ttl_slots {
+    if let Some(ttl_slots) = operation.ttl_slots {
         tokens.push(format!("ttl_slots={ttl_slots}"));
     }
+}
 
-    tokens.push(format!("outcome={}", event.outcome.kind().as_str()));
-    match &event.outcome {
+fn encode_outcome_tokens(outcome: &JepsenEventOutcome, tokens: &mut Vec<String>) {
+    match outcome {
         JepsenEventOutcome::CommittedWrite(write) => {
             tokens.push(format!("applied_lsn={}", write.applied_lsn.get()));
             tokens.push(format!("write_result={}", write.result.as_str()));
             match &write.result {
                 JepsenWriteResult::Reserved {
                     reservation_id,
+                    lease_epoch,
                     holder_id,
                     expires_at_slot,
                     ..
                 } => {
                     tokens.push(format!("committed_reservation_id={reservation_id}"));
                     tokens.push(format!("committed_holder_id={holder_id}"));
+                    tokens.push(format!("committed_lease_epoch={lease_epoch}"));
                     tokens.push(format!("expires_at_slot={}", expires_at_slot.get()));
                 }
                 JepsenWriteResult::Confirmed {
                     reservation_id,
+                    lease_epoch,
                     holder_id,
                     ..
                 } => {
                     tokens.push(format!("committed_reservation_id={reservation_id}"));
                     tokens.push(format!("committed_holder_id={holder_id}"));
+                    tokens.push(format!("committed_lease_epoch={lease_epoch}"));
                 }
                 JepsenWriteResult::Released {
                     reservation_id,
@@ -897,6 +987,10 @@ fn encode_history_event(event: &JepsenHistoryEvent) -> String {
                         "released_lsn={}",
                         released_lsn.map_or(String::from("none"), |lsn| lsn.get().to_string())
                     ));
+                }
+                JepsenWriteResult::Revoked { reservation_id }
+                | JepsenWriteResult::Reclaimed { reservation_id } => {
+                    tokens.push(format!("committed_reservation_id={reservation_id}"));
                 }
                 JepsenWriteResult::TickExpired { expired } => {
                     tokens.push(format!("expired={}", encode_expired_reservations(expired)));
@@ -931,7 +1025,6 @@ fn encode_history_event(event: &JepsenHistoryEvent) -> String {
             tokens.push(format!("reason={}", reason.as_str()));
         }
     }
-    tokens.join(" ")
 }
 
 fn decode_history_event(
@@ -942,8 +1035,10 @@ fn decode_history_event(
         kind,
         operation_id: optional_u128_field(fields, "operation_id")?,
         resource_id: optional_resource_id_field(fields, "resource_id")?,
+        resource_ids: optional_resource_ids_field(fields, "resource_ids")?,
         reservation_id: optional_u128_field(fields, "reservation_id")?,
         holder_id: optional_u128_field(fields, "holder_id")?,
+        lease_epoch: optional_u64_field(fields, "lease_epoch")?,
         required_lsn: optional_lsn_field(fields, "required_lsn")?,
         request_slot: optional_slot_field(fields, "request_slot")?,
         ttl_slots: optional_u64_field(fields, "ttl_slots")?,
@@ -990,6 +1085,7 @@ fn decode_write_result(
             resource_id: operation
                 .resource_id
                 .ok_or_else(|| JepsenCodecError::MissingField(String::from("resource_id")))?,
+            lease_epoch: parse_required_u64(fields, "committed_lease_epoch")?,
             holder_id: parse_required_u128(fields, "committed_holder_id")?,
             reservation_id: parse_required_u128(fields, "committed_reservation_id")?,
             expires_at_slot: parse_required_slot(fields, "expires_at_slot")?,
@@ -998,6 +1094,7 @@ fn decode_write_result(
             resource_id: operation
                 .resource_id
                 .ok_or_else(|| JepsenCodecError::MissingField(String::from("resource_id")))?,
+            lease_epoch: parse_required_u64(fields, "committed_lease_epoch")?,
             holder_id: parse_required_u128(fields, "committed_holder_id")?,
             reservation_id: parse_required_u128(fields, "committed_reservation_id")?,
         }),
@@ -1008,6 +1105,12 @@ fn decode_write_result(
             holder_id: parse_required_u128(fields, "committed_holder_id")?,
             reservation_id: parse_required_u128(fields, "committed_reservation_id")?,
             released_lsn: optional_lsn_field(fields, "released_lsn")?,
+        }),
+        "revoked" => Ok(JepsenWriteResult::Revoked {
+            reservation_id: parse_required_u128(fields, "committed_reservation_id")?,
+        }),
+        "reclaimed" => Ok(JepsenWriteResult::Reclaimed {
+            reservation_id: parse_required_u128(fields, "committed_reservation_id")?,
         }),
         "tick_expired" => Ok(JepsenWriteResult::TickExpired {
             expired: decode_expired_reservations(required_field(fields, "expired")?)?,
@@ -1177,6 +1280,18 @@ fn optional_resource_id_field(
         .transpose()
 }
 
+fn optional_resource_ids_field(
+    fields: &BTreeMap<String, String>,
+    field: &str,
+) -> Result<Vec<ResourceId>, JepsenCodecError> {
+    fields.get(field).map_or(Ok(Vec::new()), |value| {
+        decode_resource_ids(value).map_err(|_| JepsenCodecError::InvalidField {
+            field: String::from(field),
+            value: value.clone(),
+        })
+    })
+}
+
 fn parse_optional_lsn(field: &str, value: &str) -> Result<Option<Lsn>, JepsenCodecError> {
     if value == "none" {
         return Ok(None);
@@ -1218,6 +1333,24 @@ fn encode_expired_reservations(expired: &[JepsenExpiredReservation]) -> String {
         })
         .collect::<Vec<_>>()
         .join(",")
+}
+
+fn encode_resource_ids(resource_ids: &[ResourceId]) -> String {
+    resource_ids
+        .iter()
+        .map(|resource_id| resource_id.get().to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn decode_resource_ids(value: &str) -> Result<Vec<ResourceId>, std::num::ParseIntError> {
+    if value.is_empty() {
+        return Ok(Vec::new());
+    }
+    value
+        .split(',')
+        .map(|entry| entry.parse::<u128>().map(ResourceId))
+        .collect()
 }
 
 fn decode_expired_reservations(
@@ -1450,26 +1583,32 @@ fn fingerprint_write(write: &JepsenCommittedWrite) -> CommittedFingerprint {
     match &write.result {
         JepsenWriteResult::Reserved {
             resource_id,
+            lease_epoch,
             holder_id,
             reservation_id,
             expires_at_slot,
         } => CommittedFingerprint {
             applied_lsn: write.applied_lsn,
             resource_id: Some(*resource_id),
+            resource_ids: Vec::new(),
             reservation_id: Some(*reservation_id),
             holder_id: Some(*holder_id),
+            lease_epoch: Some(*lease_epoch),
             released_lsn: None,
             expires_at_slot: Some(*expires_at_slot),
         },
         JepsenWriteResult::Confirmed {
             resource_id,
+            lease_epoch,
             holder_id,
             reservation_id,
         } => CommittedFingerprint {
             applied_lsn: write.applied_lsn,
             resource_id: Some(*resource_id),
+            resource_ids: Vec::new(),
             reservation_id: Some(*reservation_id),
             holder_id: Some(*holder_id),
+            lease_epoch: Some(*lease_epoch),
             released_lsn: None,
             expires_at_slot: None,
         },
@@ -1481,16 +1620,31 @@ fn fingerprint_write(write: &JepsenCommittedWrite) -> CommittedFingerprint {
         } => CommittedFingerprint {
             applied_lsn: write.applied_lsn,
             resource_id: Some(*resource_id),
+            resource_ids: Vec::new(),
             reservation_id: Some(*reservation_id),
             holder_id: Some(*holder_id),
+            lease_epoch: None,
             released_lsn: *released_lsn,
+            expires_at_slot: None,
+        },
+        JepsenWriteResult::Revoked { reservation_id }
+        | JepsenWriteResult::Reclaimed { reservation_id } => CommittedFingerprint {
+            applied_lsn: write.applied_lsn,
+            resource_id: None,
+            resource_ids: Vec::new(),
+            reservation_id: Some(*reservation_id),
+            holder_id: None,
+            lease_epoch: None,
+            released_lsn: None,
             expires_at_slot: None,
         },
         JepsenWriteResult::TickExpired { .. } => CommittedFingerprint {
             applied_lsn: write.applied_lsn,
             resource_id: None,
+            resource_ids: Vec::new(),
             reservation_id: None,
             holder_id: None,
+            lease_epoch: None,
             released_lsn: None,
             expires_at_slot: None,
         },
@@ -1524,6 +1678,14 @@ fn render_blocker(blocker: &JepsenBlockingIssue) -> String {
         } => format!(
             "blocker=double_allocation resource_id={} existing_operation_id={existing_operation_id} conflicting_operation_id={conflicting_operation_id}",
             resource_id.get()
+        ),
+        JepsenBlockingIssue::StaleHolderNotRejected {
+            reservation_id,
+            operation_id,
+            attempted_epoch,
+            current_epoch,
+        } => format!(
+            "blocker=stale_holder_not_rejected reservation_id={reservation_id} operation_id={operation_id} attempted_epoch={attempted_epoch} current_epoch={current_epoch}"
         ),
         JepsenBlockingIssue::StaleSuccessfulRead(violation) => format!(
             "blocker=stale_successful_read replica_id={} role={} required_lsn={} observed_lsn={}",
@@ -1570,6 +1732,12 @@ struct ResourceLeaseState {
     operation_id: u128,
     reservation_id: u128,
     expires_at_slot: Slot,
+}
+
+#[derive(Clone, Debug)]
+struct ReservationLeaseState {
+    member_resource_ids: Vec<ResourceId>,
+    lease_epoch: u64,
 }
 
 fn collect_mutating_attempts(
@@ -1628,9 +1796,12 @@ fn record_committed_attempt(
     operation: JepsenOperation,
     write: JepsenCommittedWrite,
 ) {
-    let fingerprint = fingerprint_write(&write);
-    if let Some(existing) = builder.committed_result {
-        if existing != fingerprint {
+    let mut fingerprint = fingerprint_write(&write);
+    if !operation.resource_ids.is_empty() {
+        fingerprint.resource_ids.clone_from(&operation.resource_ids);
+    }
+    if let Some(existing) = &builder.committed_result {
+        if *existing != fingerprint {
             blockers.push(JepsenBlockingIssue::DuplicateCommittedExecution {
                 operation_id,
                 first_lsn: existing.applied_lsn,
@@ -1705,100 +1876,132 @@ fn check_committed_release_blockers(
 ) -> Vec<JepsenBlockingIssue> {
     let mut blockers = Vec::new();
     let mut resources = BTreeMap::<u128, ResourceLeaseState>::new();
+    let mut reservations = BTreeMap::<u128, ReservationLeaseState>::new();
     for record in committed.into_values() {
-        apply_committed_record(&mut resources, &mut blockers, &record);
+        apply_committed_record(&mut resources, &mut reservations, &mut blockers, &record);
     }
     blockers
 }
 
 fn apply_committed_record(
     resources: &mut BTreeMap<u128, ResourceLeaseState>,
+    reservations: &mut BTreeMap<u128, ReservationLeaseState>,
     blockers: &mut Vec<JepsenBlockingIssue>,
     record: &CommittedRecord,
 ) {
     match &record.write.result {
         JepsenWriteResult::Reserved {
-            resource_id,
             reservation_id,
             expires_at_slot,
+            lease_epoch,
             ..
         } => record_reserved_write(
             resources,
+            reservations,
             blockers,
-            *resource_id,
+            record,
             *reservation_id,
             *expires_at_slot,
-            record.operation_id,
+            *lease_epoch,
         ),
-        JepsenWriteResult::Confirmed {
-            resource_id,
-            reservation_id,
-            ..
-        } => record_confirmed_write(
-            resources,
-            blockers,
-            *resource_id,
-            *reservation_id,
-            record.operation_id,
-        ),
-        JepsenWriteResult::Released {
-            resource_id,
-            reservation_id,
-            ..
-        } => {
-            remove_matching_reservation(resources, *resource_id, *reservation_id);
+        JepsenWriteResult::Confirmed { reservation_id, .. } => {
+            record_confirmed_write(
+                resources,
+                reservations,
+                blockers,
+                *reservation_id,
+                record.operation_id,
+            );
+        }
+        JepsenWriteResult::Released { reservation_id, .. }
+        | JepsenWriteResult::Reclaimed { reservation_id } => {
+            remove_matching_reservation(resources, reservations, *reservation_id);
+        }
+        JepsenWriteResult::Revoked { reservation_id } => {
+            record_revoked_write(reservations, *reservation_id);
         }
         JepsenWriteResult::TickExpired { expired } => {
-            record_tick_expiration(resources, blockers, &record.operation, expired);
+            record_tick_expiration(
+                resources,
+                reservations,
+                blockers,
+                &record.operation,
+                expired,
+            );
         }
     }
 }
 
 fn record_reserved_write(
     resources: &mut BTreeMap<u128, ResourceLeaseState>,
+    reservations: &mut BTreeMap<u128, ReservationLeaseState>,
     blockers: &mut Vec<JepsenBlockingIssue>,
-    resource_id: ResourceId,
+    record: &CommittedRecord,
     reservation_id: u128,
     expires_at_slot: Slot,
-    operation_id: u128,
+    lease_epoch: u64,
 ) {
-    if let Some(existing) = resources.get(&resource_id.get()) {
-        blockers.push(JepsenBlockingIssue::DoubleAllocation {
-            resource_id,
-            existing_operation_id: existing.operation_id,
-            conflicting_operation_id: operation_id,
-        });
+    let member_resource_ids = record_bundle_resource_ids(record);
+    for resource_id in &member_resource_ids {
+        if let Some(existing) = resources.get(&resource_id.get()) {
+            blockers.push(JepsenBlockingIssue::DoubleAllocation {
+                resource_id: *resource_id,
+                existing_operation_id: existing.operation_id,
+                conflicting_operation_id: record.operation_id,
+            });
+        }
+        resources.insert(
+            resource_id.get(),
+            ResourceLeaseState {
+                operation_id: record.operation_id,
+                reservation_id,
+                expires_at_slot,
+            },
+        );
     }
-    resources.insert(
-        resource_id.get(),
-        ResourceLeaseState {
-            operation_id,
-            reservation_id,
-            expires_at_slot,
+    reservations.insert(
+        reservation_id,
+        ReservationLeaseState {
+            member_resource_ids,
+            lease_epoch,
         },
     );
 }
 
 fn record_confirmed_write(
     resources: &BTreeMap<u128, ResourceLeaseState>,
+    reservations: &mut BTreeMap<u128, ReservationLeaseState>,
     blockers: &mut Vec<JepsenBlockingIssue>,
-    resource_id: ResourceId,
     reservation_id: u128,
     operation_id: u128,
 ) {
-    if let Some(existing) = resources.get(&resource_id.get()) {
-        if existing.reservation_id != reservation_id {
-            blockers.push(JepsenBlockingIssue::DoubleAllocation {
-                resource_id,
-                existing_operation_id: existing.operation_id,
-                conflicting_operation_id: operation_id,
-            });
+    if let Some(existing_reservation) = reservations.get(&reservation_id).cloned() {
+        for resource_id in existing_reservation.member_resource_ids {
+            if let Some(existing) = resources.get(&resource_id.get()) {
+                if existing.reservation_id != reservation_id {
+                    blockers.push(JepsenBlockingIssue::DoubleAllocation {
+                        resource_id,
+                        existing_operation_id: existing.operation_id,
+                        conflicting_operation_id: operation_id,
+                    });
+                }
+            }
         }
+    }
+}
+
+fn record_revoked_write(
+    reservations: &mut BTreeMap<u128, ReservationLeaseState>,
+    reservation_id: u128,
+) {
+    if let Some(reservation) = reservations.get_mut(&reservation_id) {
+        reservation.lease_epoch = reservation.lease_epoch.saturating_add(1);
     }
 }
 
 fn record_tick_expiration(
     resources: &mut BTreeMap<u128, ResourceLeaseState>,
+    reservations: &mut BTreeMap<u128, ReservationLeaseState>,
     blockers: &mut Vec<JepsenBlockingIssue>,
     operation: &JepsenOperation,
     expired: &[JepsenExpiredReservation],
@@ -1817,7 +2020,11 @@ fn record_tick_expiration(
                         released_at_slot: release_slot,
                     });
                 }
-                resources.remove(&expired_reservation.resource_id.get());
+                remove_matching_reservation(
+                    resources,
+                    reservations,
+                    expired_reservation.reservation_id,
+                );
             }
         }
     }
@@ -1825,15 +2032,96 @@ fn record_tick_expiration(
 
 fn remove_matching_reservation(
     resources: &mut BTreeMap<u128, ResourceLeaseState>,
-    resource_id: ResourceId,
+    reservations: &mut BTreeMap<u128, ReservationLeaseState>,
     reservation_id: u128,
 ) {
-    if resources
-        .get(&resource_id.get())
-        .is_some_and(|existing| existing.reservation_id == reservation_id)
-    {
-        resources.remove(&resource_id.get());
+    if let Some(reservation) = reservations.remove(&reservation_id) {
+        for resource_id in reservation.member_resource_ids {
+            if resources
+                .get(&resource_id.get())
+                .is_some_and(|existing| existing.reservation_id == reservation_id)
+            {
+                resources.remove(&resource_id.get());
+            }
+        }
     }
+}
+
+fn record_bundle_resource_ids(record: &CommittedRecord) -> Vec<ResourceId> {
+    if record.operation.resource_ids.is_empty() {
+        record
+            .operation
+            .resource_id
+            .into_iter()
+            .collect::<Vec<ResourceId>>()
+    } else {
+        record.operation.resource_ids.clone()
+    }
+}
+
+fn check_stale_holder_rejection(events: &[JepsenHistoryEvent]) -> Vec<JepsenBlockingIssue> {
+    let mut blockers = Vec::new();
+    let mut current_epochs = BTreeMap::<u128, u64>::new();
+
+    for event in events {
+        if let (Some(reservation_id), Some(attempted_epoch)) =
+            (event.operation.reservation_id, event.operation.lease_epoch)
+        {
+            if matches!(
+                event.operation.kind,
+                JepsenOperationKind::Confirm | JepsenOperationKind::Release
+            ) {
+                if let Some(current_epoch) = current_epochs.get(&reservation_id) {
+                    if attempted_epoch < *current_epoch
+                        && !matches!(
+                            event.outcome,
+                            JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::StaleEpoch)
+                        )
+                    {
+                        blockers.push(JepsenBlockingIssue::StaleHolderNotRejected {
+                            reservation_id,
+                            operation_id: event.operation.operation_id.unwrap_or(0),
+                            attempted_epoch,
+                            current_epoch: *current_epoch,
+                        });
+                    }
+                }
+            }
+        }
+
+        if let JepsenEventOutcome::CommittedWrite(write) = &event.outcome {
+            match &write.result {
+                JepsenWriteResult::Reserved {
+                    reservation_id,
+                    lease_epoch,
+                    ..
+                }
+                | JepsenWriteResult::Confirmed {
+                    reservation_id,
+                    lease_epoch,
+                    ..
+                } => {
+                    current_epochs.insert(*reservation_id, *lease_epoch);
+                }
+                JepsenWriteResult::Released { reservation_id, .. }
+                | JepsenWriteResult::Reclaimed { reservation_id } => {
+                    current_epochs.remove(reservation_id);
+                }
+                JepsenWriteResult::Revoked { reservation_id } => {
+                    if let Some(current_epoch) = current_epochs.get_mut(reservation_id) {
+                        *current_epoch = current_epoch.saturating_add(1);
+                    }
+                }
+                JepsenWriteResult::TickExpired { expired } => {
+                    for expired_reservation in expired {
+                        current_epochs.remove(&expired_reservation.reservation_id);
+                    }
+                }
+            }
+        }
+    }
+
+    blockers
 }
 
 fn summarize_logical_commands(

--- a/crates/allocdb-node/src/jepsen_tests.rs
+++ b/crates/allocdb-node/src/jepsen_tests.rs
@@ -5,11 +5,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use allocdb_core::ids::{Lsn, ResourceId, Slot};
 
 use super::{
-    JepsenAmbiguousOutcome, JepsenBlockingIssue, JepsenCommittedWrite, JepsenEventOutcome,
-    JepsenExpiredReservation, JepsenHistoryEvent, JepsenOperation, JepsenOperationKind,
-    JepsenReadState, JepsenReadTarget, JepsenResourceState, JepsenSuccessfulRead,
-    JepsenWorkloadFamily, JepsenWriteResult, analyze_history, create_artifact_bundle,
-    decode_history, encode_history, release_gate_plan,
+    JepsenAmbiguousOutcome, JepsenBlockingIssue, JepsenCommittedWrite, JepsenDefiniteFailure,
+    JepsenEventOutcome, JepsenExpiredReservation, JepsenHistoryEvent, JepsenOperation,
+    JepsenOperationKind, JepsenReadState, JepsenReadTarget, JepsenResourceState,
+    JepsenSuccessfulRead, JepsenWorkloadFamily, JepsenWriteResult, analyze_history,
+    create_artifact_bundle, decode_history, encode_history, release_gate_plan,
 };
 use crate::replica::{ReplicaId, ReplicaRole};
 
@@ -42,8 +42,10 @@ fn reserve_event(spec: ReserveEventSpec) -> JepsenHistoryEvent {
             kind: JepsenOperationKind::Reserve,
             operation_id: Some(spec.operation_id),
             resource_id: Some(ResourceId(spec.resource_id)),
+            resource_ids: Vec::new(),
             reservation_id: None,
             holder_id: Some(spec.holder_id),
+            lease_epoch: None,
             required_lsn: None,
             request_slot: Some(Slot(spec.request_slot)),
             ttl_slots: Some(spec.expires_at_slot.saturating_sub(spec.request_slot)),
@@ -52,6 +54,7 @@ fn reserve_event(spec: ReserveEventSpec) -> JepsenHistoryEvent {
             applied_lsn: Lsn(spec.applied_lsn),
             result: JepsenWriteResult::Reserved {
                 resource_id: ResourceId(spec.resource_id),
+                lease_epoch: 1,
                 holder_id: spec.holder_id,
                 reservation_id: spec.reservation_id,
                 expires_at_slot: Slot(spec.expires_at_slot),
@@ -77,8 +80,10 @@ fn release_event(
             kind: JepsenOperationKind::Release,
             operation_id: Some(operation_id),
             resource_id: Some(ResourceId(resource_id)),
+            resource_ids: Vec::new(),
             reservation_id: Some(reservation_id),
             holder_id: Some(holder_id),
+            lease_epoch: Some(1),
             required_lsn: None,
             request_slot: Some(Slot(request_slot)),
             ttl_slots: None,
@@ -90,6 +95,48 @@ fn release_event(
                 holder_id,
                 reservation_id,
                 released_lsn: Some(Lsn(applied_lsn)),
+            },
+        }),
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ReserveBundleEventSpec<'a> {
+    sequence: u64,
+    operation_id: u128,
+    request_slot: u64,
+    applied_lsn: u64,
+    resource_ids: &'a [u128],
+    holder_id: u128,
+    reservation_id: u128,
+    expires_at_slot: u64,
+}
+
+fn reserve_bundle_event(spec: ReserveBundleEventSpec<'_>) -> JepsenHistoryEvent {
+    JepsenHistoryEvent {
+        sequence: spec.sequence,
+        process: String::from("client-1"),
+        time_millis: u128::from(spec.sequence),
+        operation: JepsenOperation {
+            kind: JepsenOperationKind::ReserveBundle,
+            operation_id: Some(spec.operation_id),
+            resource_id: spec.resource_ids.first().copied().map(ResourceId),
+            resource_ids: spec.resource_ids.iter().copied().map(ResourceId).collect(),
+            reservation_id: None,
+            holder_id: Some(spec.holder_id),
+            lease_epoch: None,
+            required_lsn: None,
+            request_slot: Some(Slot(spec.request_slot)),
+            ttl_slots: Some(spec.expires_at_slot.saturating_sub(spec.request_slot)),
+        },
+        outcome: JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
+            applied_lsn: Lsn(spec.applied_lsn),
+            result: JepsenWriteResult::Reserved {
+                resource_id: ResourceId(spec.resource_ids[0]),
+                lease_epoch: 1,
+                holder_id: spec.holder_id,
+                reservation_id: spec.reservation_id,
+                expires_at_slot: Slot(spec.expires_at_slot),
             },
         }),
     }
@@ -129,8 +176,10 @@ fn analysis_resolves_ambiguous_write_through_retry_cache() {
                 kind: JepsenOperationKind::Reserve,
                 operation_id: Some(91),
                 resource_id: Some(ResourceId(11)),
+                resource_ids: Vec::new(),
                 reservation_id: None,
                 holder_id: Some(7),
+                lease_epoch: None,
                 required_lsn: None,
                 request_slot: Some(Slot(5)),
                 ttl_slots: Some(3),
@@ -201,8 +250,10 @@ fn analysis_flags_stale_successful_read() {
             kind: JepsenOperationKind::GetResource,
             operation_id: None,
             resource_id: Some(ResourceId(11)),
+            resource_ids: Vec::new(),
             reservation_id: None,
             holder_id: None,
+            lease_epoch: None,
             required_lsn: Some(Lsn(9)),
             request_slot: None,
             ttl_slots: None,
@@ -246,8 +297,10 @@ fn analysis_flags_early_expiration_release() {
                 kind: JepsenOperationKind::TickExpirations,
                 operation_id: Some(42),
                 resource_id: None,
+                resource_ids: Vec::new(),
                 reservation_id: None,
                 holder_id: None,
+                lease_epoch: None,
                 required_lsn: None,
                 request_slot: Some(Slot(7)),
                 ttl_slots: None,
@@ -288,8 +341,10 @@ fn history_codec_round_trips_none_lsn_and_tick_expired_without_resource_id() {
                 kind: JepsenOperationKind::GetResource,
                 operation_id: None,
                 resource_id: Some(ResourceId(91)),
+                resource_ids: Vec::new(),
                 reservation_id: None,
                 holder_id: None,
+                lease_epoch: None,
                 required_lsn: None,
                 request_slot: None,
                 ttl_slots: None,
@@ -310,8 +365,10 @@ fn history_codec_round_trips_none_lsn_and_tick_expired_without_resource_id() {
                 kind: JepsenOperationKind::TickExpirations,
                 operation_id: Some(501),
                 resource_id: None,
+                resource_ids: Vec::new(),
                 reservation_id: None,
                 holder_id: None,
+                lease_epoch: None,
                 required_lsn: None,
                 request_slot: Some(Slot(17)),
                 ttl_slots: None,
@@ -367,4 +424,177 @@ fn history_codec_round_trips_and_artifact_bundle_is_written() {
     assert!(bundle_dir.join("manifest.txt").exists());
 
     fs::remove_dir_all(output_root).unwrap();
+}
+
+#[test]
+fn history_codec_round_trips_bundle_and_lease_epoch_fields() {
+    let history = vec![
+        reserve_bundle_event(ReserveBundleEventSpec {
+            sequence: 1,
+            operation_id: 81,
+            request_slot: 10,
+            applied_lsn: 4,
+            resource_ids: &[11, 12],
+            holder_id: 7,
+            reservation_id: 301,
+            expires_at_slot: 16,
+        }),
+        JepsenHistoryEvent {
+            sequence: 2,
+            process: String::from("client-1"),
+            time_millis: 2,
+            operation: JepsenOperation {
+                kind: JepsenOperationKind::Release,
+                operation_id: Some(82),
+                resource_id: Some(ResourceId(11)),
+                resource_ids: vec![ResourceId(11), ResourceId(12)],
+                reservation_id: Some(301),
+                holder_id: Some(7),
+                lease_epoch: Some(1),
+                required_lsn: None,
+                request_slot: Some(Slot(11)),
+                ttl_slots: None,
+            },
+            outcome: JepsenEventOutcome::DefiniteFailure(JepsenDefiniteFailure::StaleEpoch),
+        },
+    ];
+
+    let encoded = encode_history(&history);
+    let decoded = decode_history(&encoded).unwrap();
+    assert_eq!(decoded, history);
+}
+
+#[test]
+fn analysis_flags_stale_holder_not_rejected_after_revoke() {
+    let history = vec![
+        reserve_bundle_event(ReserveBundleEventSpec {
+            sequence: 1,
+            operation_id: 91,
+            request_slot: 10,
+            applied_lsn: 4,
+            resource_ids: &[11, 12],
+            holder_id: 7,
+            reservation_id: 401,
+            expires_at_slot: 16,
+        }),
+        JepsenHistoryEvent {
+            sequence: 2,
+            process: String::from("controller"),
+            time_millis: 2,
+            operation: JepsenOperation {
+                kind: JepsenOperationKind::Revoke,
+                operation_id: Some(92),
+                resource_id: None,
+                resource_ids: Vec::new(),
+                reservation_id: Some(401),
+                holder_id: None,
+                lease_epoch: None,
+                required_lsn: None,
+                request_slot: Some(Slot(11)),
+                ttl_slots: None,
+            },
+            outcome: JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
+                applied_lsn: Lsn(5),
+                result: JepsenWriteResult::Revoked {
+                    reservation_id: 401,
+                },
+            }),
+        },
+        JepsenHistoryEvent {
+            sequence: 3,
+            process: String::from("client-1"),
+            time_millis: 3,
+            operation: JepsenOperation {
+                kind: JepsenOperationKind::Release,
+                operation_id: Some(93),
+                resource_id: Some(ResourceId(11)),
+                resource_ids: vec![ResourceId(11), ResourceId(12)],
+                reservation_id: Some(401),
+                holder_id: Some(7),
+                lease_epoch: Some(1),
+                required_lsn: None,
+                request_slot: Some(Slot(12)),
+                ttl_slots: None,
+            },
+            outcome: JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
+                applied_lsn: Lsn(6),
+                result: JepsenWriteResult::Released {
+                    resource_id: ResourceId(11),
+                    holder_id: 7,
+                    reservation_id: 401,
+                    released_lsn: Some(Lsn(6)),
+                },
+            }),
+        },
+    ];
+
+    let report = analyze_history(&history);
+    assert!(report.blockers.iter().any(|blocker| matches!(
+        blocker,
+        JepsenBlockingIssue::StaleHolderNotRejected {
+            reservation_id: 401,
+            operation_id: 93,
+            attempted_epoch: 1,
+            current_epoch: 2,
+        }
+    )));
+}
+
+#[test]
+fn analysis_flags_double_allocation_before_reclaim_after_revoke() {
+    let history = vec![
+        reserve_bundle_event(ReserveBundleEventSpec {
+            sequence: 1,
+            operation_id: 101,
+            request_slot: 10,
+            applied_lsn: 4,
+            resource_ids: &[11, 12],
+            holder_id: 7,
+            reservation_id: 501,
+            expires_at_slot: 16,
+        }),
+        JepsenHistoryEvent {
+            sequence: 2,
+            process: String::from("controller"),
+            time_millis: 2,
+            operation: JepsenOperation {
+                kind: JepsenOperationKind::Revoke,
+                operation_id: Some(102),
+                resource_id: None,
+                resource_ids: Vec::new(),
+                reservation_id: Some(501),
+                holder_id: None,
+                lease_epoch: None,
+                required_lsn: None,
+                request_slot: Some(Slot(11)),
+                ttl_slots: None,
+            },
+            outcome: JepsenEventOutcome::CommittedWrite(JepsenCommittedWrite {
+                applied_lsn: Lsn(5),
+                result: JepsenWriteResult::Revoked {
+                    reservation_id: 501,
+                },
+            }),
+        },
+        reserve_bundle_event(ReserveBundleEventSpec {
+            sequence: 3,
+            operation_id: 103,
+            request_slot: 12,
+            applied_lsn: 6,
+            resource_ids: &[11, 12],
+            holder_id: 8,
+            reservation_id: 502,
+            expires_at_slot: 18,
+        }),
+    ];
+
+    let report = analyze_history(&history);
+    assert!(report.blockers.iter().any(|blocker| matches!(
+        blocker,
+        JepsenBlockingIssue::DoubleAllocation {
+            resource_id,
+            existing_operation_id: 101,
+            conflicting_operation_id: 103,
+        } if *resource_id == ResourceId(11) || *resource_id == ResourceId(12)
+    )));
 }

--- a/docs/status.md
+++ b/docs/status.md
@@ -14,7 +14,7 @@
   - `M6` replication design: implemented
   - `M7` replicated core prototype: in progress
   - `M8` external cluster validation: in progress
-  - `M9` generic lease-kernel follow-on: `T10` merged, `T11` broader regression coverage in progress
+  - `M9` generic lease-kernel follow-on: implementation merged on `main`
 - Latest completed implementation chunks:
   - `4156a80` `Bootstrap AllocDB core and docs`
   - `f84a641` `Add WAL file and snapshot recovery primitives`
@@ -102,10 +102,12 @@
   - deterministic cluster-simulation plan that extends seeded simulation to partitions, primary
     crash, and rejoin without a mock semantics layer
   - Jepsen gate with explicit contention, ambiguity, failover, and expiration workloads
+  - supplementary Jepsen lease-safety coverage for bundle reserve, revoke/reclaim, and stale-holder rejection without changing the documented release-gate matrix
   - retry-aware history interpretation and release-blocking invariants for duplicate execution,
-    stale successful reads, double allocation, and early reuse
+    stale successful reads, double allocation, early reuse, and stale-holder acceptance
 - Host-side Jepsen harness slice:
   - one release-gate matrix planner, one retry-aware history codec/analyzer, one host-side artifact bundler for duplicate-execution, double-allocation, stale-read, early-expiration, unresolved-ambiguity, and fetched external-cluster log checks, plus explicit `verify-qemu-surface` and `verify-kubevirt-surface` probes that exercise one real metrics round trip on every replica and one real primary submit/read round trip through the live replicated protocol surface
+  - one supplementary `lease_safety` workload family with control and crash-restart runs that exercises bundle reserve, explicit revoke/reclaim, and stale-holder release against the live Jepsen surface without promoting that workload into the release-blocking matrix yet
   - one real `run-qemu` and one real `run-kubevirt` executor for the full documented release-gate matrix, with persisted histories and artifact bundles for control, crash-restart, partition-heal, and mixed-failover runs, plus host-side failover/rejoin orchestration built from replica workspace export/import and staged `ReplicaNode::recover(...)` rewrites
   - one `capture-kubevirt-layout` helper that records the live KubeVirt VM IPs, namespace, helper-pod settings, and SSH key path needed to drive the matrix from the host
 - Replicated node scaffolding:
@@ -198,23 +200,14 @@
 - PR `#82` merged the `#70` maintainability follow-up, including live KubeVirt `reservation_contention-control`
   and full `1800s` `reservation_contention-crash-restart` reruns on `allocdb-a` with `blockers=0`
 - `M9-T01` through `M9-T05` are merged on `main` via PR `#81`, and the planning issues are closed on the `AllocDB` project
-- PR `#89` merged `M9-T06` on `main`: the trusted core now supports atomic bundle reservation,
-  explicit bundle membership records, bundle-aware confirm/release/expire, and bundle-aware
-  snapshot/codec coverage while preserving the existing reservation compatibility surface
-- PR `#90` merged `M9-T07` on `main`: lease epochs now flow through holder-authorized commands and
-  command outcomes, the core rejects stale holder epochs deterministically, and read/retry
-  surfaces expose the current authority token for active reservations
-- PR `#92` merged `M9-T08` on `main`: the trusted core now has explicit `revoke` / `reclaim`
-  commands, `revoking` and `revoked` states, and deterministic duplicate/recovery handling
-- PR `#93` merged `M9-T09` on `main`: the node API and wire codec now expose the approved
-  lease-centric surface with `get_lease`, flattened committed results, `current_lease_id`, and
-  ordered `member_resource_ids`, while keeping the trusted-core naming and apply path intact
-- PR `#94` merged `M9-T10` on `main`: replication and failover now preserve committed bundle
-  membership plus stale-holder rejection without introducing a second apply path
-- issue `#88` / `M9-T11` is the active implementation slice on the current branch: broaden
-  deterministic simulation and replicated regression coverage for bundle retries, revoke races,
-  stale-holder rejection, crash recovery, and failover
-- targeted validation on the active `#88` branch currently centers on `cargo test -p allocdb-node simulation -- --nocapture`,
-  `cargo test -p allocdb-node replicated_simulation -- --nocapture`, and `./scripts/preflight.sh`
-- the active `#88` branch is the final planned `M9` code-bearing slice before any new milestone
-  planning
+- PRs `#89`, `#90`, `#92`, `#93`, `#94`, and `#95` merged the full `M9-T06` through `M9-T11`
+  implementation chain on `main`: bundle commit, lease-epoch fencing, explicit `revoke` /
+  `reclaim`, lease-shaped node API exposure, replication-preserved failover behavior, and broader
+  simulation coverage are now all in the mainline implementation
+- issue `#96` is the active follow-on validation slice on the current branch: extend Jepsen
+  history generation and analysis for bundle reserve, revoke/reclaim, and stale-holder lease
+  paths, then run a small live KubeVirt matrix for that workload
+- targeted validation on the active `#96` branch currently centers on `cargo test -p allocdb-node jepsen -- --nocapture`,
+  `cargo test -p allocdb-node --bin allocdb-jepsen -- --nocapture`, and `./scripts/preflight.sh`
+- the next recommended step after `#96` is either live KubeVirt lease-safety validation or new
+  milestone planning beyond `M9`, not more unplanned lease-kernel semantics work

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -617,6 +617,26 @@ Checks:
 - restarted and rejoined replicas converge on committed history before serving or voting
 - recovery preserves the same client-visible result for retried operations
 
+### Supplementary Lease Coverage
+
+The release-blocking matrix stays on the four workload families above. Lease-kernel follow-on
+work uses one separate non-blocking workload family so bundle, fencing, and revoke behavior can
+be exercised on the real Jepsen surface without silently changing the documented gate size.
+
+#### Lease Safety
+
+- reserve one bundle atomically, confirm it, revoke it, and reclaim it later
+- issue one holder-authorized command with a stale `lease_epoch` after revoke
+- try one pre-reclaim bundle reuse and one post-reclaim bundle reuse
+- run the workload in at least one control lane and one faulted lane, currently
+  `lease_safety-control` and `lease_safety-crash-restart`
+
+Checks:
+
+- bundle ownership remains all-or-nothing across retries and failover
+- revoked ownership is not reusable before explicit `reclaim`
+- stale holders fail with `stale_epoch` rather than succeeding or drifting into a weaker outcome
+
 ### Nemesis Families
 
 The first Jepsen gate should explicitly cover:


### PR DESCRIPTION
Closes #96

## Summary
- add non-release-blocking `lease_safety` Jepsen runs alongside the existing release-gate matrix
- extend Jepsen history encoding, event mapping, and analysis for bundle reserve, revoke/reclaim, and stale-holder rejection
- add focused Jepsen unit tests plus status/testing doc updates for the supplementary lease workload

## Validation
- `cargo test -p allocdb-node jepsen -- --nocapture`
- `cargo test -p allocdb-node --bin allocdb-jepsen -- --nocapture`
- `./scripts/preflight.sh`

## Follow-up On This Branch
- run the live KubeVirt `lease_safety-control` and one faulted `lease_safety` lane and attach the artifact paths before merge
